### PR TITLE
feat: order/book on WhatsApp from product, service, cart, and floating bubble

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.core.middleware import (
 )
 
 # Import routers
-from app.routers import auth, services, bookings, gallery, testimonials, products as public_products, promo_codes as public_promo_codes, reviews as public_reviews, cart, wishlist, vision, classes, site_settings as public_site_settings
+from app.routers import auth, services, bookings, gallery, testimonials, products as public_products, promo_codes as public_promo_codes, reviews as public_reviews, cart, wishlist, vision, classes, site_settings as public_site_settings, whatsapp as whatsapp_router
 from app.api.routes import brands, categories, products, product_images, product_variants, service_packages, orders, reviews
 from app.api.routes.admin import locations as admin_locations, calendar as admin_calendar, bookings as admin_bookings, gallery as admin_gallery, users as admin_users, testimonials as admin_testimonials, promo_codes as admin_promo_codes, analytics as admin_analytics, vision as admin_vision, activity_logs as admin_activity_logs, booking_analytics, classes as admin_classes, site_settings as admin_site_settings, storage_settings as admin_storage_settings, instagram_settings as admin_instagram_settings
 
@@ -132,6 +132,7 @@ app.include_router(admin_site_settings.router, prefix="/api")  # Admin site sett
 app.include_router(admin_storage_settings.router, prefix="/api")  # Admin storage settings API
 app.include_router(admin_instagram_settings.router, prefix="/api")  # Admin Instagram settings API
 app.include_router(public_site_settings.router, prefix="/api")  # Public site settings API
+app.include_router(whatsapp_router.router, prefix="/api")  # WhatsApp deep-link API
 
 # Serve uploaded files when using local storage (non-S3)
 uploads_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "uploads")

--- a/backend/app/routers/whatsapp.py
+++ b/backend/app/routers/whatsapp.py
@@ -1,0 +1,186 @@
+"""WhatsApp deep-link generation.
+
+Returns a `wa.me` URL with a pre-filled message so customers can convert
+through WhatsApp without exposing the configured number in the frontend
+bundle. The number is stored in `SiteSetting` under key
+`whatsapp_phone_number` and is never returned to the client directly —
+only embedded inside the redirect URL at click time.
+"""
+import json
+import re
+from decimal import Decimal
+from typing import List, Optional, Tuple
+from urllib.parse import quote
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.dependencies import get_optional_current_user
+from app.models.product import Product
+from app.models.service import ServicePackage
+from app.models.user import User
+from app.schemas.whatsapp import (
+    WhatsAppCartRequest,
+    WhatsAppGeneralRequest,
+    WhatsAppLinkRequest,
+    WhatsAppLinkResponse,
+    WhatsAppProductRequest,
+    WhatsAppServiceRequest,
+)
+from app.services import site_settings_service
+
+router = APIRouter(prefix="/whatsapp", tags=["WhatsApp"])
+
+PHONE_KEY = "whatsapp_phone_number"
+PHONE_REGEX = re.compile(r"^\d{8,15}$")
+
+
+def _load_phone(db: Session) -> str:
+    raw = site_settings_service.get_setting(db, PHONE_KEY)
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp ordering is not configured.",
+        )
+    # Stored values are JSON-encoded by upsert_setting.
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        value = raw
+    if not isinstance(value, str):
+        value = str(value)
+    digits = re.sub(r"\D", "", value)
+    if not PHONE_REGEX.match(digits):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp number is configured incorrectly.",
+        )
+    return digits
+
+
+def _fmt_ksh(amount: Decimal) -> str:
+    # Whole-shilling display; WhatsApp messages are plain text.
+    return f"KSh {amount:,.0f}"
+
+
+def _service_starting_price(pkg: ServicePackage) -> Optional[Decimal]:
+    candidates = [
+        pkg.base_bride_price,
+        pkg.base_maid_price,
+        pkg.base_mother_price,
+        pkg.base_other_price,
+    ]
+    prices = [Decimal(p) for p in candidates if p is not None]
+    return min(prices) if prices else None
+
+
+def _user_lines(user: Optional[User]) -> List[str]:
+    if not user:
+        return []
+    lines = []
+    if user.full_name:
+        lines.append(f"Name: {user.full_name}")
+    if user.email:
+        lines.append(f"Email: {user.email}")
+    return lines
+
+
+def _build_product_message(
+    db: Session, req: WhatsAppProductRequest, user: Optional[User]
+) -> str:
+    product = db.query(Product).filter(Product.id == req.product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    price = Decimal(product.base_price)
+    line_total = price * req.quantity
+    lines = [
+        "Hi Glam by Lynn — I'd like to order:",
+        f"• {product.title} × {req.quantity} — {_fmt_ksh(line_total)}",
+        f"Total: {_fmt_ksh(line_total)}",
+    ]
+    lines.extend(_user_lines(user))
+    return "\n".join(lines)
+
+
+def _build_service_message(
+    db: Session, req: WhatsAppServiceRequest, user: Optional[User]
+) -> str:
+    pkg = db.query(ServicePackage).filter(ServicePackage.id == req.service_id).first()
+    if not pkg:
+        raise HTTPException(status_code=404, detail="Service not found")
+    price = _service_starting_price(pkg)
+    price_str = f" — from {_fmt_ksh(price)}" if price is not None else ""
+    lines = [
+        "Hi Glam by Lynn — I'd like to book:",
+        f"• {pkg.name}{price_str}",
+    ]
+    if req.preferred_date:
+        # Strip any control chars from the free-text date.
+        safe_date = re.sub(r"[\x00-\x1f]", "", req.preferred_date)[:64]
+        lines.append(f"Preferred date: {safe_date}")
+    lines.extend(_user_lines(user))
+    return "\n".join(lines)
+
+
+def _build_cart_message(
+    db: Session, req: WhatsAppCartRequest, user: Optional[User]
+) -> str:
+    if not req.items:
+        raise HTTPException(status_code=400, detail="Cart is empty")
+    ids = [item.product_id for item in req.items]
+    products = {
+        p.id: p
+        for p in db.query(Product).filter(Product.id.in_(ids)).all()
+    }
+    item_lines: List[str] = []
+    total = Decimal(0)
+    for item in req.items:
+        product = products.get(item.product_id)
+        if not product:
+            continue
+        price = Decimal(product.base_price)
+        line_total = price * item.quantity
+        total += line_total
+        item_lines.append(
+            f"• {product.title} × {item.quantity} — {_fmt_ksh(line_total)}"
+        )
+    if not item_lines:
+        raise HTTPException(status_code=404, detail="No valid items in cart")
+    lines = ["Hi Glam by Lynn — I'd like to order:"]
+    lines.extend(item_lines)
+    lines.append(f"Total: {_fmt_ksh(total)}")
+    lines.extend(_user_lines(user))
+    return "\n".join(lines)
+
+
+def _build_general_message(user: Optional[User]) -> str:
+    lines = ["Hi Glam by Lynn — I have a question."]
+    lines.extend(_user_lines(user))
+    return "\n".join(lines)
+
+
+@router.post(
+    "/link",
+    response_model=WhatsAppLinkResponse,
+    summary="Generate a pre-filled WhatsApp redirect URL",
+)
+def generate_link(
+    payload: WhatsAppLinkRequest = Body(..., discriminator="type"),
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_current_user),
+):
+    phone = _load_phone(db)
+
+    if isinstance(payload, WhatsAppProductRequest):
+        message = _build_product_message(db, payload, current_user)
+    elif isinstance(payload, WhatsAppServiceRequest):
+        message = _build_service_message(db, payload, current_user)
+    elif isinstance(payload, WhatsAppCartRequest):
+        message = _build_cart_message(db, payload, current_user)
+    else:
+        message = _build_general_message(current_user)
+
+    url = f"https://wa.me/{phone}?text={quote(message)}"
+    return WhatsAppLinkResponse(url=url)

--- a/backend/app/schemas/whatsapp.py
+++ b/backend/app/schemas/whatsapp.py
@@ -1,0 +1,43 @@
+"""Schemas for the WhatsApp link generation endpoint."""
+from typing import List, Literal, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class WhatsAppCartItem(BaseModel):
+    product_id: UUID
+    quantity: int = Field(default=1, ge=1, le=999)
+
+
+class WhatsAppProductRequest(BaseModel):
+    type: Literal["product"]
+    product_id: UUID
+    quantity: int = Field(default=1, ge=1, le=999)
+
+
+class WhatsAppServiceRequest(BaseModel):
+    type: Literal["service"]
+    service_id: UUID
+    preferred_date: Optional[str] = Field(default=None, max_length=64)
+
+
+class WhatsAppCartRequest(BaseModel):
+    type: Literal["cart"]
+    items: List[WhatsAppCartItem] = Field(default_factory=list, max_length=100)
+
+
+class WhatsAppGeneralRequest(BaseModel):
+    type: Literal["general"]
+
+
+WhatsAppLinkRequest = Union[
+    WhatsAppProductRequest,
+    WhatsAppServiceRequest,
+    WhatsAppCartRequest,
+    WhatsAppGeneralRequest,
+]
+
+
+class WhatsAppLinkResponse(BaseModel):
+    url: str

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -34,6 +34,7 @@ import {
   Instagram,
   RefreshCw,
   ExternalLink,
+  MessageCircle,
 } from "lucide-react";
 import { extractErrorMessage } from "@/lib/error-utils";
 import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
@@ -52,6 +53,12 @@ export default function AdminSettingsPage() {
   const [featureToggles, setFeatureToggles] = useState({
     enable_newsletter: false,
   });
+
+  // WhatsApp ordering (persisted via API as site setting)
+  const [whatsappPhone, setWhatsappPhone] = useState("");
+  const [whatsappSaving, setWhatsappSaving] = useState(false);
+  const [whatsappSuccess, setWhatsappSuccess] = useState("");
+  const [whatsappError, setWhatsappError] = useState("");
 
   // Business Info
   const [businessInfo, setBusinessInfo] = useState({
@@ -157,6 +164,7 @@ export default function AdminSettingsPage() {
             tiktok: data.social_tiktok ?? "",
             youtube: data.social_youtube ?? "",
           }));
+          setWhatsappPhone(data.whatsapp_phone_number ?? "");
         }
 
         // Load Instagram settings
@@ -238,6 +246,44 @@ export default function AdminSettingsPage() {
       setSaveError(extractErrorMessage(err, "Failed to save feature toggles"));
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleSaveWhatsapp = async () => {
+    setWhatsappSaving(true);
+    setWhatsappError("");
+    setWhatsappSuccess("");
+
+    const digits = whatsappPhone.replace(/\D/g, "");
+    if (digits && (digits.length < 8 || digits.length > 15)) {
+      setWhatsappError(
+        "Enter a valid phone number with country code (8–15 digits, no '+')."
+      );
+      setWhatsappSaving(false);
+      return;
+    }
+
+    try {
+      const token = (session as any)?.accessToken;
+      const response = await fetch(
+        `${API_BASE_URL}${API_ENDPOINTS.SETTINGS.ADMIN_UPDATE}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ whatsapp_phone_number: digits }),
+        }
+      );
+      if (!response.ok) throw new Error("Failed to save WhatsApp number");
+      setWhatsappPhone(digits);
+      setWhatsappSuccess("WhatsApp number saved");
+      setTimeout(() => setWhatsappSuccess(""), 3000);
+    } catch (err: any) {
+      setWhatsappError(extractErrorMessage(err, "Failed to save WhatsApp number"));
+    } finally {
+      setWhatsappSaving(false);
     }
   };
 
@@ -569,6 +615,53 @@ export default function AdminSettingsPage() {
                 </div>
               </>
             )}
+          </CardContent>
+        </Card>
+
+        {/* WhatsApp Ordering Section */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MessageCircle className="h-5 w-5" />
+              WhatsApp Ordering
+            </CardTitle>
+            <CardDescription>
+              Phone number used for the “Order/Book on WhatsApp” buttons. Stored
+              server-side and never exposed in the public site bundle.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {whatsappSuccess && (
+              <div className="bg-green-50 border-l-4 border-green-500 text-green-700 p-3 rounded text-sm">
+                {whatsappSuccess}
+              </div>
+            )}
+            {whatsappError && (
+              <div className="bg-red-50 border-l-4 border-red-500 text-red-700 p-3 rounded text-sm">
+                {whatsappError}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="whatsapp-phone">WhatsApp Phone Number</Label>
+              <Input
+                id="whatsapp-phone"
+                inputMode="numeric"
+                value={whatsappPhone}
+                onChange={(e) => setWhatsappPhone(e.target.value)}
+                placeholder="254712345678"
+              />
+              <p className="text-xs text-muted-foreground">
+                Digits only, including country code, no leading “+”. Example:
+                <code className="ml-1 rounded bg-muted px-1 py-0.5">254712345678</code>.
+                Leave empty to disable WhatsApp ordering.
+              </p>
+            </div>
+            <div className="flex justify-end">
+              <Button onClick={handleSaveWhatsapp} disabled={whatsappSaving}>
+                <Save className="mr-2 h-4 w-4" />
+                {whatsappSaving ? "Saving..." : "Save Changes"}
+              </Button>
+            </div>
           </CardContent>
         </Card>
 

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -10,6 +10,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -998,25 +999,39 @@ function BookingFormContent() {
             </div>
 
             {/* Navigation */}
-            <div className="mt-8 flex justify-between">
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-between">
               <Button variant="outline" onClick={prevStep} size="lg">
                 <ChevronLeft className="mr-2 h-4 w-4" />
                 Back
               </Button>
-              <Button
-                onClick={handleSubmit}
-                disabled={!canSubmit || attendeeErrors.length > 0 || submitting}
-                size="lg"
-              >
-                {submitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Confirming Booking...
-                  </>
-                ) : (
-                  "Confirm Booking"
+              <div className="flex flex-col gap-3 sm:flex-row">
+                {selectedPackage && (
+                  <WhatsAppButton
+                    variant="outline"
+                    size="lg"
+                    label="Book on WhatsApp"
+                    context={{
+                      type: "service",
+                      service_id: selectedPackage.id,
+                      preferred_date: bookingDate || undefined,
+                    }}
+                  />
                 )}
-              </Button>
+                <Button
+                  onClick={handleSubmit}
+                  disabled={!canSubmit || attendeeErrors.length > 0 || submitting}
+                  size="lg"
+                >
+                  {submitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Confirming Booking...
+                    </>
+                  ) : (
+                    "Confirm Booking"
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/app/cart/page.tsx
+++ b/frontend/src/app/cart/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -331,6 +332,20 @@ export default function CartPage() {
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Link>
                   </Button>
+
+                  <WhatsAppButton
+                    size="lg"
+                    variant="primary"
+                    label="Order on WhatsApp"
+                    className="w-full"
+                    context={{
+                      type: "cart",
+                      items: cartItems.map((it) => ({
+                        product_id: it.product.id,
+                        quantity: it.quantity,
+                      })),
+                    }}
+                  />
 
                   <Button asChild variant="outline" size="lg" className="w-full">
                     <Link href="/products">Continue Shopping</Link>

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -614,6 +615,21 @@ export default function CheckoutPage() {
                       "Place Order"
                     )}
                   </Button>
+
+                  <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+                    <span>or</span>
+                    <WhatsAppButton
+                      variant="link"
+                      label="Order on WhatsApp instead"
+                      context={{
+                        type: "cart",
+                        items: cartItems.map((it) => ({
+                          product_id: it.product.id,
+                          quantity: it.quantity,
+                        })),
+                      }}
+                    />
+                  </div>
 
                   <p className="text-xs text-center text-muted-foreground">
                     {!authenticated && "You're checking out as a guest. "}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SessionProvider } from "@/components/providers/SessionProvider";
 import { constructMetadata } from "@/lib/metadata";
 import { OrganizationStructuredData } from "@/components/StructuredData";
 import { Toaster } from "@/components/ui/sonner";
+import { WhatsAppFloatingButton } from "@/components/WhatsAppFloatingButton";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,6 +39,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <SessionProvider>{children}</SessionProvider>
+        <WhatsAppFloatingButton />
         <Toaster position="top-right" richColors />
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -398,6 +399,12 @@ export default function Home() {
                           <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                         </Link>
                       </Button>
+                      <WhatsAppButton
+                        variant="link"
+                        label="Book on WhatsApp"
+                        className="self-center"
+                        context={{ type: "service", service_id: service.id }}
+                      />
                     </CardContent>
                     </Card>
                   </FadeInSection>
@@ -609,6 +616,16 @@ export default function Home() {
                                 Add to Bag
                               </button>
                             )}
+                            <div
+                              className="mt-2 flex justify-center"
+                              onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                            >
+                              <WhatsAppButton
+                                variant="link"
+                                label="Order on WhatsApp"
+                                context={{ type: "product", product_id: product.id, quantity: 1 }}
+                              />
+                            </div>
                           </div>
                         </div>
                       </Link>

--- a/frontend/src/app/products/[id]/page.tsx
+++ b/frontend/src/app/products/[id]/page.tsx
@@ -16,6 +16,7 @@ import { ReviewSubmissionForm } from "@/components/ReviewSubmissionForm";
 import { RatingSummary } from "@/components/RatingSummary";
 import { ReviewList } from "@/components/ReviewList";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -664,7 +665,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
             )}
 
             {/* Action Buttons */}
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
               <Button
                 size="lg"
                 className="flex-1"
@@ -697,6 +698,17 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
                   />
                 )}
               </Button>
+              <WhatsAppButton
+                size="lg"
+                variant="primary"
+                label="Order on WhatsApp"
+                className="w-full sm:w-auto"
+                context={{
+                  type: "product",
+                  product_id: product.id,
+                  quantity,
+                }}
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -768,6 +769,18 @@ export default function ProductsPage() {
                               )}
                               Add to Bag
                             </button>
+                          )}
+                          {!isOutOfStock && (
+                            <div
+                              className="mt-2 flex justify-center"
+                              onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                            >
+                              <WhatsAppButton
+                                variant="link"
+                                label="Order on WhatsApp"
+                                context={{ type: "product", product_id: product.id, quantity: 1 }}
+                              />
+                            </div>
                           )}
                         </div>
                       </div>

--- a/frontend/src/app/services/page.tsx
+++ b/frontend/src/app/services/page.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ServicePackage } from "@/types";
@@ -145,6 +146,12 @@ export default function ServicesPage() {
                         >
                           Book Now
                         </Button>
+                        <WhatsAppButton
+                          variant="outline"
+                          label="Book on WhatsApp"
+                          className="w-full"
+                          context={{ type: "service", service_id: pkg.id }}
+                        />
                       </div>
                     </CardContent>
                   </Card>

--- a/frontend/src/components/WhatsAppButton.tsx
+++ b/frontend/src/components/WhatsAppButton.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { MessageCircle, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import { cn } from "@/lib/utils";
+
+export type WhatsAppContext =
+  | { type: "product"; product_id: string; quantity?: number }
+  | { type: "service"; service_id: string; preferred_date?: string }
+  | { type: "cart"; items: Array<{ product_id: string; quantity: number }> }
+  | { type: "general" };
+
+type Variant = "primary" | "outline" | "icon" | "link";
+
+interface WhatsAppButtonProps {
+  context: WhatsAppContext;
+  variant?: Variant;
+  label?: string;
+  className?: string;
+  size?: "sm" | "default" | "lg";
+  disabled?: boolean;
+  onContextError?: (message: string) => void;
+}
+
+const WhatsAppGlyph = ({ className }: { className?: string }) => (
+  <MessageCircle className={className} aria-hidden="true" />
+);
+
+export function WhatsAppButton({
+  context,
+  variant = "outline",
+  label = "Chat on WhatsApp",
+  className,
+  size = "default",
+  disabled,
+  onContextError,
+}: WhatsAppButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (loading || disabled) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE_URL}${API_ENDPOINTS.WHATSAPP.LINK}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(context),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        const message =
+          (detail && (detail.detail as string)) ||
+          "Unable to open WhatsApp right now. Please try again.";
+        if (res.status === 503) {
+          onContextError?.(message);
+        }
+        toast.error(message);
+        return;
+      }
+      const data = (await res.json()) as { url: string };
+      window.open(data.url, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      console.error("WhatsApp link error", error);
+      toast.error("Unable to open WhatsApp right now. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading || disabled}
+        aria-label={label}
+        className={cn(
+          "inline-flex items-center justify-center rounded-full bg-[#25D366] text-white shadow-sm transition hover:bg-[#1ebe57] disabled:opacity-60",
+          "h-9 w-9",
+          className,
+        )}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <WhatsAppGlyph className="h-4 w-4" />
+        )}
+      </button>
+    );
+  }
+
+  if (variant === "link") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading || disabled}
+        className={cn(
+          "inline-flex items-center gap-1.5 text-sm font-medium text-[#1ebe57] hover:underline disabled:opacity-60",
+          className,
+        )}
+      >
+        {loading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <WhatsAppGlyph className="h-3.5 w-3.5" />
+        )}
+        {label}
+      </button>
+    );
+  }
+
+  const isPrimary = variant === "primary";
+
+  return (
+    <Button
+      type="button"
+      onClick={handleClick}
+      disabled={loading || disabled}
+      size={size}
+      variant={isPrimary ? "default" : "outline"}
+      className={cn(
+        isPrimary
+          ? "bg-[#25D366] text-white hover:bg-[#1ebe57]"
+          : "border-[#25D366] text-[#1ebe57] hover:bg-[#25D366]/10",
+        className,
+      )}
+    >
+      {loading ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <WhatsAppGlyph className="h-4 w-4" />
+      )}
+      {label}
+    </Button>
+  );
+}
+
+export default WhatsAppButton;

--- a/frontend/src/components/WhatsAppFloatingButton.tsx
+++ b/frontend/src/components/WhatsAppFloatingButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { WhatsAppButton } from "@/components/WhatsAppButton";
+
+export function WhatsAppFloatingButton() {
+  const pathname = usePathname() ?? "";
+
+  if (pathname.startsWith("/admin")) return null;
+
+  return (
+    <div className="fixed bottom-5 right-5 z-50 sm:bottom-6 sm:right-6">
+      <WhatsAppButton
+        context={{ type: "general" }}
+        variant="icon"
+        label="Chat with Glam by Lynn on WhatsApp"
+        className="h-14 w-14 shadow-lg [&_svg]:h-6 [&_svg]:w-6"
+      />
+    </div>
+  );
+}
+
+export default WhatsAppFloatingButton;

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -126,6 +126,10 @@ export const API_ENDPOINTS = {
       EXPORT_CSV: "/api/admin/classes/enrollments/export/csv",
     },
   },
+  // WhatsApp
+  WHATSAPP: {
+    LINK: "/api/whatsapp/link",
+  },
   // Site Settings
   SETTINGS: {
     PUBLIC: "/api/settings/public",


### PR DESCRIPTION
## Summary
- Adds a one-click WhatsApp ordering/booking path on the product detail page, product cards (homepage + listing), service cards, cart, checkout, booking review step, and a site-wide floating bubble (hidden on `/admin/*`).
- The configured number lives only on the backend (`SiteSetting` key `whatsapp_phone_number`, not in `PUBLIC_KEYS`) and is embedded into a `wa.me` redirect at click time by `POST /api/whatsapp/link`. Backend pulls authoritative names/prices from the DB and prepends the signed-in user's name/email when present — guests are not asked to identify themselves.
- New admin field at `/admin/settings → WhatsApp Ordering` to set/rotate the number; light validation (8–15 digits, no `+`).

## Test plan
- [ ] Configure number at `/admin/settings → WhatsApp Ordering` (e.g. `254712345678`); confirm it persists via `GET /api/admin/settings`.
- [ ] `curl -X POST :PORT/api/whatsapp/link -H 'Content-Type: application/json' -d '{"type":"general"}'` returns a `wa.me` URL; returns 503 when unset.
- [ ] Product page: "Order on WhatsApp" opens a new tab with product name, qty, and total prefilled.
- [ ] Service / bookings review: "Book on WhatsApp" includes service name + starting price + preferred date when set.
- [ ] Cart / checkout: cart-context CTA lists each item × qty with a total.
- [ ] Signed-in user: message includes `Name:` / `Email:` lines. Signed-out: those lines are absent.
- [ ] Floating bubble shows on public pages, hidden on `/admin/*`.
- [ ] `grep -r "<the-number>" frontend/.next/` after `npm run build` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)