### PR TITLE
feat(whatsapp): bordered green CTA + deep links to product/service pages

### DIFF
--- a/backend/app/routers/whatsapp.py
+++ b/backend/app/routers/whatsapp.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.dependencies import get_optional_current_user
 from app.models.product import Product
@@ -65,6 +66,20 @@ def _fmt_ksh(amount: Decimal) -> str:
     return f"KSh {amount:,.0f}"
 
 
+def _site_base_url() -> str:
+    return settings.FRONTEND_URL.rstrip("/")
+
+
+def _product_url(product: Product) -> str:
+    return f"{_site_base_url()}/products/{product.id}"
+
+
+def _service_url(pkg: ServicePackage) -> str:
+    # No per-service detail page exists; deep-link the booking wizard with the
+    # package pre-selected so the recipient lands on the right context.
+    return f"{_site_base_url()}/bookings/new?packageId={pkg.id}"
+
+
 def _service_starting_price(pkg: ServicePackage) -> Optional[Decimal]:
     candidates = [
         pkg.base_bride_price,
@@ -98,6 +113,7 @@ def _build_product_message(
     lines = [
         "Hi Glam by Lynn — I'd like to order:",
         f"• {product.title} × {req.quantity} — {_fmt_ksh(line_total)}",
+        f"  {_product_url(product)}",
         f"Total: {_fmt_ksh(line_total)}",
     ]
     lines.extend(_user_lines(user))
@@ -115,6 +131,7 @@ def _build_service_message(
     lines = [
         "Hi Glam by Lynn — I'd like to book:",
         f"• {pkg.name}{price_str}",
+        f"  {_service_url(pkg)}",
     ]
     if req.preferred_date:
         # Strip any control chars from the free-text date.
@@ -146,6 +163,7 @@ def _build_cart_message(
         item_lines.append(
             f"• {product.title} × {item.quantity} — {_fmt_ksh(line_total)}"
         )
+        item_lines.append(f"  {_product_url(product)}")
     if not item_lines:
         raise HTTPException(status_code=404, detail="No valid items in cart")
     lines = ["Hi Glam by Lynn — I'd like to order:"]

--- a/frontend/src/app/cart/page.tsx
+++ b/frontend/src/app/cart/page.tsx
@@ -335,9 +335,8 @@ export default function CartPage() {
 
                   <WhatsAppButton
                     size="lg"
-                    variant="primary"
+                    variant="outline"
                     label="Order on WhatsApp"
-                    className="w-full"
                     context={{
                       type: "cart",
                       items: cartItems.map((it) => ({

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -616,20 +616,17 @@ export default function CheckoutPage() {
                     )}
                   </Button>
 
-                  <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
-                    <span>or</span>
-                    <WhatsAppButton
-                      variant="link"
-                      label="Order on WhatsApp instead"
-                      context={{
-                        type: "cart",
-                        items: cartItems.map((it) => ({
-                          product_id: it.product.id,
-                          quantity: it.quantity,
-                        })),
-                      }}
-                    />
-                  </div>
+                  <WhatsAppButton
+                    variant="outline"
+                    label="Order on WhatsApp"
+                    context={{
+                      type: "cart",
+                      items: cartItems.map((it) => ({
+                        product_id: it.product.id,
+                        quantity: it.quantity,
+                      })),
+                    }}
+                  />
 
                   <p className="text-xs text-center text-muted-foreground">
                     {!authenticated && "You're checking out as a guest. "}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -400,9 +400,8 @@ export default function Home() {
                         </Link>
                       </Button>
                       <WhatsAppButton
-                        variant="link"
+                        variant="outline"
                         label="Book on WhatsApp"
-                        className="self-center"
                         context={{ type: "service", service_id: service.id }}
                       />
                     </CardContent>
@@ -621,8 +620,9 @@ export default function Home() {
                               onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
                             >
                               <WhatsAppButton
-                                variant="link"
+                                variant="outline"
                                 label="Order on WhatsApp"
+                                size="sm"
                                 context={{ type: "product", product_id: product.id, quantity: 1 }}
                               />
                             </div>

--- a/frontend/src/app/products/[id]/page.tsx
+++ b/frontend/src/app/products/[id]/page.tsx
@@ -700,9 +700,8 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
               </Button>
               <WhatsAppButton
                 size="lg"
-                variant="primary"
+                variant="outline"
                 label="Order on WhatsApp"
-                className="w-full sm:w-auto"
                 context={{
                   type: "product",
                   product_id: product.id,

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -776,8 +776,9 @@ export default function ProductsPage() {
                               onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
                             >
                               <WhatsAppButton
-                                variant="link"
+                                variant="outline"
                                 label="Order on WhatsApp"
+                                size="sm"
                                 context={{ type: "product", product_id: product.id, quantity: 1 }}
                               />
                             </div>

--- a/frontend/src/components/WhatsAppButton.tsx
+++ b/frontend/src/components/WhatsAppButton.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { MessageCircle, Loader2 } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
 import { cn } from "@/lib/utils";
 
@@ -14,7 +13,7 @@ export type WhatsAppContext =
   | { type: "cart"; items: Array<{ product_id: string; quantity: number }> }
   | { type: "general" };
 
-type Variant = "primary" | "outline" | "icon" | "link";
+type Variant = "outline" | "icon";
 
 interface WhatsAppButtonProps {
   context: WhatsAppContext;
@@ -80,7 +79,7 @@ export function WhatsAppButton({
         disabled={loading || disabled}
         aria-label={label}
         className={cn(
-          "inline-flex items-center justify-center rounded-full bg-[#25D366] text-white shadow-sm transition hover:bg-[#1ebe57] disabled:opacity-60",
+          "inline-flex items-center justify-center rounded-full bg-green-500 text-white shadow-sm transition hover:bg-green-600 disabled:opacity-60",
           "h-9 w-9",
           className,
         )}
@@ -94,40 +93,22 @@ export function WhatsAppButton({
     );
   }
 
-  if (variant === "link") {
-    return (
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={loading || disabled}
-        className={cn(
-          "inline-flex items-center gap-1.5 text-sm font-medium text-[#1ebe57] hover:underline disabled:opacity-60",
-          className,
-        )}
-      >
-        {loading ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <WhatsAppGlyph className="h-3.5 w-3.5" />
-        )}
-        {label}
-      </button>
-    );
-  }
-
-  const isPrimary = variant === "primary";
+  const sizeClasses =
+    size === "sm"
+      ? "py-2 text-sm"
+      : size === "lg"
+        ? "py-3.5 text-base"
+        : "py-3 text-sm";
 
   return (
-    <Button
+    <button
       type="button"
       onClick={handleClick}
       disabled={loading || disabled}
-      size={size}
-      variant={isPrimary ? "default" : "outline"}
       className={cn(
-        isPrimary
-          ? "bg-[#25D366] text-white hover:bg-[#1ebe57]"
-          : "border-[#25D366] text-[#1ebe57] hover:bg-[#25D366]/10",
+        "w-full flex items-center justify-center gap-2 rounded-2xl font-bold transition-all disabled:opacity-60 disabled:cursor-not-allowed",
+        "border-2 border-green-500 text-green-600 hover:bg-green-50",
+        sizeClasses,
         className,
       )}
     >
@@ -137,7 +118,7 @@ export function WhatsAppButton({
         <WhatsAppGlyph className="h-4 w-4" />
       )}
       {label}
-    </Button>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replaces the underlined-link and solid WhatsApp variants with a single bordered green outline style across product detail, product cards, cart, checkout, services, bookings review step, and homepage featured sections. `WhatsAppButton.tsx` now exposes only `outline | icon` (TS will flag any leftover usage).
- Pre-filled message now includes a clickable deep link beneath each product (`FRONTEND_URL/products/{id}`) and beneath the service (`FRONTEND_URL/bookings/new?packageId={id}`) so the artist can tap straight to the right page from WhatsApp. Base URL is read from the existing `FRONTEND_URL` backend setting — no client changes for staging/prod.

## Test plan
- [ ] Visit `/`, `/products`, `/products/[id]`, `/services`, `/cart`, `/checkout`, `/bookings/new` — every WhatsApp CTA renders as the bordered green pill with `hover:bg-green-50`, no underline.
- [ ] `POST /api/whatsapp/link` with `type:product` returns a message containing `FRONTEND_URL/products/{id}` under the line.
- [ ] `type:service` → message contains `FRONTEND_URL/bookings/new?packageId={id}`.
- [ ] `type:cart` → URL appears beneath each item line.
- [ ] `FRONTEND_URL` env var on the staging backend resolves to the staging origin so links work when WhatsApp auto-linkifies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)