### PR TITLE
feat(og): rich product/service social previews with image, price, description

### DIFF
--- a/frontend/src/app/products/[id]/layout.tsx
+++ b/frontend/src/app/products/[id]/layout.tsx
@@ -1,0 +1,113 @@
+/**
+ * Product detail server layout — owns the per-product `<meta>` tags so
+ * social previews unfurl with real title/description/price next to the
+ * auto-generated OpenGraph image. The actual page body is the existing
+ * client component in `./page.tsx`.
+ */
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import { siteConfig } from "@/lib/metadata";
+import { trimDescription } from "@/lib/og-templates";
+import type { Product } from "@/types";
+
+async function getProduct(id: string): Promise<Product | null> {
+  try {
+    const res = await fetch(
+      `${API_BASE_URL}${API_ENDPOINTS.PRODUCTS.DETAIL(id)}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as Product;
+  } catch (error) {
+    console.error("metadata product fetch failed", error);
+    return null;
+  }
+}
+
+function formatKsh(raw: string | number | undefined | null): string | null {
+  if (raw === null || raw === undefined || raw === "") return null;
+  const n = typeof raw === "string" ? Number.parseFloat(raw) : raw;
+  if (!Number.isFinite(n)) return null;
+  return `KSh ${Math.round(n).toLocaleString("en-KE")}`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }> | { id: string };
+}): Promise<Metadata> {
+  const resolved = await params;
+  const product = await getProduct(resolved.id);
+
+  if (!product) {
+    return {
+      title: "Product not available",
+      description:
+        "This product may have been removed. Browse the full Glam by Lynn collection.",
+      robots: { index: false, follow: true },
+    };
+  }
+
+  const price = formatKsh(product.final_price ?? product.base_price);
+  const inStock = (product.in_stock ?? product.inventory_count > 0) === true;
+  const trimmedDesc = trimDescription(product.description, 160);
+  const description = [
+    price ? `${price}.` : null,
+    trimmedDesc || "Quality beauty product from Glam by Lynn.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const canonical = `${siteConfig.url}/products/${product.id}`;
+  const title = product.brand?.name
+    ? `${product.title} — ${product.brand.name}`
+    : product.title;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      title,
+      description,
+      url: canonical,
+      siteName: siteConfig.name,
+      locale: "en_KE",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      creator: "@glambylynn",
+    },
+    other: {
+      // Product-specific OG metadata recognised by Facebook, WhatsApp,
+      // and Pinterest rich-pin crawlers.
+      ...(price
+        ? {
+            "og:price:amount": String(
+              product.final_price ?? product.base_price,
+            ),
+            "og:price:currency": "KES",
+            "product:price:amount": String(
+              product.final_price ?? product.base_price,
+            ),
+            "product:price:currency": "KES",
+          }
+        : {}),
+      "product:availability": inStock ? "in stock" : "out of stock",
+      ...(product.brand?.name ? { "product:brand": product.brand.name } : {}),
+      ...(product.category?.name
+        ? { "product:category": product.category.name }
+        : {}),
+    },
+  };
+}
+
+export default function ProductLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/products/[id]/opengraph-image.tsx
+++ b/frontend/src/app/products/[id]/opengraph-image.tsx
@@ -1,79 +1,105 @@
 /**
  * Product Detail OpenGraph Image
- * Generates dynamic OG image for individual product pages
+ *
+ * Renders a 1200×630 social preview with the product's primary image,
+ * name, price (with compare-at strike-through when discounted), category,
+ * brand, stock state, and a sentence-trimmed description.
  */
 
-import { ImageResponse } from '@vercel/og';
-import { ProductOGTemplate } from '@/lib/og-templates';
-import { API_BASE_URL, API_ENDPOINTS } from '@/config/api';
-import { Product } from '@/types';
+import { ImageResponse } from "@vercel/og";
 
-export const runtime = 'edge';
-export const alt = 'Product - Glam by Lynn';
-export const size = {
-  width: 1200,
-  height: 630,
-};
-export const contentType = 'image/png';
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import {
+  OG_SIZE,
+  ProductOGTemplate,
+  GenericPageOGTemplate,
+  trimDescription,
+} from "@/lib/og-templates";
+import { Product } from "@/types";
+
+export const runtime = "edge";
+export const alt = "Product - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+const PRICE_FALLBACK = "Contact for pricing";
 
 async function getProduct(id: string): Promise<Product | null> {
   try {
-    const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.PRODUCTS.DETAIL(id)}`, {
-      cache: 'no-store',
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    return response.json();
+    const response = await fetch(
+      `${API_BASE_URL}${API_ENDPOINTS.PRODUCTS.DETAIL(id)}`,
+      { cache: "no-store" },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as Product;
   } catch (error) {
-    console.error('Error fetching product for OG image:', error);
+    console.error("OG product fetch failed", error);
     return null;
   }
 }
 
-export default async function Image({ params }: { params: { id: string } }) {
-  const product = await getProduct(params.id);
+function formatKsh(raw: string | number | undefined | null): string | null {
+  if (raw === null || raw === undefined || raw === "") return null;
+  const n = typeof raw === "string" ? Number.parseFloat(raw) : raw;
+  if (!Number.isFinite(n)) return null;
+  return `KSh ${Math.round(n).toLocaleString("en-KE")}`;
+}
+
+function resolvePrimaryImage(product: Product): string | undefined {
+  if (!product.images || product.images.length === 0) return undefined;
+  const primary =
+    product.images.find((img) => img.is_primary) ?? product.images[0];
+  if (!primary?.image_url) return undefined;
+  if (
+    primary.image_url.startsWith("http://") ||
+    primary.image_url.startsWith("https://")
+  ) {
+    return primary.image_url;
+  }
+  return `${API_BASE_URL}${primary.image_url}`;
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const product = await getProduct(id);
 
   if (!product) {
-    // Return a fallback image if product not found
     return new ImageResponse(
       (
-        <div
-          style={{
-            display: 'flex',
-            width: '100%',
-            height: '100%',
-            backgroundColor: '#000000',
-            color: '#FFFFFF',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: '48px',
-            fontFamily: 'Inter, system-ui, sans-serif',
-          }}
-        >
-          Product Not Found
-        </div>
+        <GenericPageOGTemplate
+          title="Product not available"
+          description="This product may have been removed. Browse the full Glam by Lynn collection at glambylynn.com."
+        />
       ),
-      { ...size }
+      { ...size },
     );
   }
 
-  const price = product.base_price
-    ? `KSh ${product.base_price.toLocaleString()}`
-    : 'Contact for pricing';
-
-  const description = product.description?.substring(0, 150) || 'Quality beauty product from Glam by Lynn';
+  const price = formatKsh(product.final_price ?? product.base_price) ?? PRICE_FALLBACK;
+  const hasDiscount =
+    product.final_price &&
+    product.base_price &&
+    Number.parseFloat(String(product.final_price)) <
+      Number.parseFloat(String(product.base_price));
+  const comparePrice = hasDiscount ? formatKsh(product.base_price) ?? undefined : undefined;
 
   return new ImageResponse(
-    <ProductOGTemplate
-      name={product.title}
-      description={description}
-      price={price}
-      category={product.category?.name}
-      inStock={product.inventory_count > 0}
-    />,
-    { ...size }
+    (
+      <ProductOGTemplate
+        name={product.title}
+        description={trimDescription(product.description, 160)}
+        price={price}
+        comparePrice={comparePrice}
+        category={product.category?.name}
+        brand={product.brand?.name}
+        inStock={(product.in_stock ?? product.inventory_count > 0) === true}
+        imageUrl={resolvePrimaryImage(product)}
+      />
+    ),
+    { ...size },
   );
 }

--- a/frontend/src/app/products/[id]/twitter-image.tsx
+++ b/frontend/src/app/products/[id]/twitter-image.tsx
@@ -1,78 +1,9 @@
 /**
  * Product Detail Twitter Card Image
- * Generates dynamic Twitter card image for individual product pages
+ *
+ * Same artwork as the OpenGraph image so X / Twitter previews stay
+ * consistent with WhatsApp, Facebook, and LinkedIn.
  */
 
-import { ImageResponse } from '@vercel/og';
-import { ProductOGTemplate } from '@/lib/og-templates';
-import { API_BASE_URL, API_ENDPOINTS } from '@/config/api';
-import { Product } from '@/types';
-
-export const runtime = 'edge';
-export const alt = 'Product - Glam by Lynn';
-export const size = {
-  width: 1200,
-  height: 630,
-};
-export const contentType = 'image/png';
-
-async function getProduct(id: string): Promise<Product | null> {
-  try {
-    const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.PRODUCTS.DETAIL(id)}`, {
-      cache: 'no-store',
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    return response.json();
-  } catch (error) {
-    console.error('Error fetching product for Twitter image:', error);
-    return null;
-  }
-}
-
-export default async function Image({ params }: { params: { id: string } }) {
-  const product = await getProduct(params.id);
-
-  if (!product) {
-    return new ImageResponse(
-      (
-        <div
-          style={{
-            display: 'flex',
-            width: '100%',
-            height: '100%',
-            backgroundColor: '#000000',
-            color: '#FFFFFF',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: '48px',
-            fontFamily: 'Inter, system-ui, sans-serif',
-          }}
-        >
-          Product Not Found
-        </div>
-      ),
-      { ...size }
-    );
-  }
-
-  const price = product.base_price
-    ? `KSh ${product.base_price.toLocaleString()}`
-    : 'Contact for pricing';
-
-  const description = product.description?.substring(0, 150) || 'Quality beauty product from Glam by Lynn';
-
-  return new ImageResponse(
-    <ProductOGTemplate
-      name={product.title}
-      description={description}
-      price={price}
-      category={product.category?.name}
-      inStock={product.inventory_count > 0}
-    />,
-    { ...size }
-  );
-}
+export { default } from "./opengraph-image";
+export { runtime, alt, size, contentType } from "./opengraph-image";

--- a/frontend/src/app/services/opengraph-image.tsx
+++ b/frontend/src/app/services/opengraph-image.tsx
@@ -1,25 +1,87 @@
 /**
  * Services OpenGraph Image
- * Generates dynamic OG image for services page
+ *
+ * Pulls the live service catalogue so the preview can quote a real
+ * "from KSh X" starting price. Falls back to a static brand panel if the
+ * API is unreachable.
  */
 
-import { ImageResponse } from '@vercel/og';
-import { GenericPageOGTemplate } from '@/lib/og-templates';
+import { ImageResponse } from "@vercel/og";
 
-export const runtime = 'edge';
-export const alt = 'Makeup & Beauty Services - Glam by Lynn';
-export const size = {
-  width: 1200,
-  height: 630,
-};
-export const contentType = 'image/png';
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import {
+  OG_SIZE,
+  ServiceOGTemplate,
+  GenericPageOGTemplate,
+} from "@/lib/og-templates";
+import type { ServicePackage } from "@/types";
+
+export const runtime = "edge";
+export const alt = "Makeup Services - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+function lowestPrice(pkg: ServicePackage): number | null {
+  const prices = [
+    pkg.base_bride_price,
+    pkg.base_maid_price,
+    pkg.base_mother_price,
+    pkg.base_other_price,
+  ]
+    .map((p) => (p ? Number.parseFloat(p) : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return prices.length ? Math.min(...prices) : null;
+}
+
+function formatKsh(n: number): string {
+  return `KSh ${Math.round(n).toLocaleString("en-KE")}`;
+}
+
+async function getStartingPrice(): Promise<number | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}${API_ENDPOINTS.SERVICES.LIST}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const payload = (await res.json()) as ServicePackage[] | { items: ServicePackage[] };
+    const items = Array.isArray(payload) ? payload : payload.items;
+    if (!items?.length) return null;
+    const all = items
+      .filter((p) => p.is_active)
+      .map(lowestPrice)
+      .filter((p): p is number => p !== null);
+    return all.length ? Math.min(...all) : null;
+  } catch (error) {
+    console.error("OG services fetch failed", error);
+    return null;
+  }
+}
 
 export default async function Image() {
+  const startingPrice = await getStartingPrice();
+
+  if (startingPrice === null) {
+    return new ImageResponse(
+      (
+        <GenericPageOGTemplate
+          title="Professional Makeup Services"
+          description="Bridal, special-occasion, and editorial makeup in Kitui & Nairobi."
+        />
+      ),
+      { ...size },
+    );
+  }
+
   return new ImageResponse(
-    <GenericPageOGTemplate
-      title="Professional Makeup Services"
-      description="Bridal makeup, special occasions, and makeup classes in Kitui & Nairobi"
-    />,
-    { ...size }
+    (
+      <ServiceOGTemplate
+        name="Professional Makeup Services"
+        description="Bridal, special-occasion, and editorial makeup tailored to your day. Trusted by clients across Kitui and Nairobi."
+        packageType="Services"
+        startingPrice={formatKsh(startingPrice)}
+        durationLabel="On-location available"
+      />
+    ),
+    { ...size },
   );
 }

--- a/frontend/src/app/services/twitter-image.tsx
+++ b/frontend/src/app/services/twitter-image.tsx
@@ -1,25 +1,2 @@
-/**
- * Services Twitter Card Image
- * Generates dynamic Twitter card image for services page
- */
-
-import { ImageResponse } from '@vercel/og';
-import { GenericPageOGTemplate } from '@/lib/og-templates';
-
-export const runtime = 'edge';
-export const alt = 'Makeup & Beauty Services - Glam by Lynn';
-export const size = {
-  width: 1200,
-  height: 630,
-};
-export const contentType = 'image/png';
-
-export default async function Image() {
-  return new ImageResponse(
-    <GenericPageOGTemplate
-      title="Professional Makeup Services"
-      description="Bridal makeup, special occasions, and makeup classes in Kitui & Nairobi"
-    />,
-    { ...size }
-  );
-}
+export { default } from "./opengraph-image";
+export { runtime, alt, size, contentType } from "./opengraph-image";

--- a/frontend/src/lib/og-templates.tsx
+++ b/frontend/src/lib/og-templates.tsx
@@ -1,204 +1,591 @@
 /**
  * OpenGraph Image Templates
- * Reusable templates for generating social media preview images
+ *
+ * Reusable templates rendered by @vercel/og's `ImageResponse`. JSX here is
+ * a small Yoga-style subset — no flex `gap`, `display: 'flex'` required on
+ * every container, no nested text spans without explicit display, etc.
  */
 
-import { CSSProperties } from 'react';
+import { CSSProperties } from "react";
 
 export const brandColors = {
-  background: '#000000',
-  foreground: '#FFFFFF',
-  secondary: '#FFB6C1', // Light Pink
-  muted: '#F5F5F5',
+  background: "#000000",
+  surface: "#0F0F10",
+  surfaceMuted: "#1A1A1C",
+  foreground: "#FFFFFF",
+  secondary: "#FFB6C1", // Light Pink
+  secondaryDeep: "#E091A6",
+  muted: "#D7D7D7",
+  mutedSubtle: "#9C9C9E",
+  success: "#22C55E",
+  danger: "#F87171",
 };
 
-export const baseStyles: Record<string, CSSProperties> = {
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '100%',
-    height: '100%',
-    backgroundColor: brandColors.background,
-    padding: '60px',
-    fontFamily: 'Inter, system-ui, sans-serif',
-  },
-  header: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: '40px',
-  },
-  logo: {
-    display: 'flex',
-    fontSize: '48px',
-    fontWeight: 'bold',
-    color: brandColors.foreground,
-  },
-  logoAccent: {
-    color: brandColors.secondary,
-  },
-  content: {
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: '72px',
-    fontWeight: 'bold',
-    color: brandColors.foreground,
-    lineHeight: 1.2,
-    marginBottom: '20px',
-  },
-  description: {
-    fontSize: '36px',
-    color: brandColors.muted,
-    lineHeight: 1.4,
-    marginBottom: '30px',
-  },
-  footer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginTop: 'auto',
-    paddingTop: '40px',
-    borderTop: `2px solid ${brandColors.secondary}`,
-  },
-  location: {
-    display: 'flex',
-    fontSize: '24px',
-    color: brandColors.secondary,
-  },
-  badge: {
-    display: 'flex',
-    padding: '12px 24px',
-    backgroundColor: brandColors.secondary,
-    color: brandColors.background,
-    fontSize: '24px',
-    fontWeight: '600',
-    borderRadius: '8px',
-  },
-  price: {
-    fontSize: '48px',
-    fontWeight: 'bold',
-    color: brandColors.secondary,
-    marginTop: '20px',
-  },
-};
+export const OG_SIZE = { width: 1200, height: 630 } as const;
 
-interface BaseOGTemplateProps {
-  title: string;
-  description?: string;
-  badge?: string;
-  price?: string;
-  showLocation?: boolean;
-}
+const fontStack = "Inter, system-ui, -apple-system, sans-serif";
 
 /**
- * Base OG Image Template
- * Can be customized for different page types
+ * Trim a description to a sentence-boundary near `max` characters. Avoids
+ * the classic "cut mid-word" ugliness in social previews.
  */
-export function BaseOGTemplate({
-  title,
-  description,
-  badge,
-  price,
-  showLocation = true,
-}: BaseOGTemplateProps) {
+export function trimDescription(text: string | undefined | null, max = 160): string {
+  if (!text) return "";
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  const slice = clean.slice(0, max + 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max * 0.6 ? slice.slice(0, lastSpace) : slice.slice(0, max);
+  return cut.replace(/[,;:.\-–—]+$/, "") + "…";
+}
+
+/** Brand wordmark used in the corner of every template. */
+function Wordmark({ size = 36 }: { size?: number }) {
   return (
-    <div style={baseStyles.container}>
-      {/* Header with Logo */}
-      <div style={baseStyles.header}>
-        <div style={baseStyles.logo}>
-          Glam by <span style={baseStyles.logoAccent}>Lynn</span>
-        </div>
-      </div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        fontSize: size,
+        fontWeight: 700,
+        letterSpacing: "-0.02em",
+        color: brandColors.foreground,
+      }}
+    >
+      <span style={{ display: "flex" }}>Glam by&nbsp;</span>
+      <span style={{ display: "flex", color: brandColors.secondary }}>Lynn</span>
+    </div>
+  );
+}
 
-      {/* Main Content */}
-      <div style={baseStyles.content}>
-        {badge && <div style={baseStyles.badge}>{badge}</div>}
-        <div style={baseStyles.title}>{title}</div>
-        {description && <div style={baseStyles.description}>{description}</div>}
-        {price && <div style={baseStyles.price}>{price}</div>}
-      </div>
+function LocationStrip() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        fontSize: 22,
+        color: brandColors.mutedSubtle,
+      }}
+    >
+      <span style={{ display: "flex" }}>📍 Kitui &amp; Nairobi, Kenya</span>
+    </div>
+  );
+}
 
-      {/* Footer */}
-      <div style={baseStyles.footer}>
-        {showLocation && (
-          <div style={baseStyles.location}>📍 Kitui & Nairobi, Kenya</div>
+/* -------------------------------------------------------------------------- */
+/*  Product template — left half: hero image; right half: name/price/desc.    */
+/* -------------------------------------------------------------------------- */
+
+interface ProductTemplateProps {
+  name: string;
+  description: string;
+  price: string;
+  comparePrice?: string;
+  category?: string;
+  brand?: string;
+  inStock: boolean;
+  imageUrl?: string;
+}
+
+const productStyles: Record<string, CSSProperties> = {
+  root: {
+    display: "flex",
+    flexDirection: "row",
+    width: "100%",
+    height: "100%",
+    backgroundColor: brandColors.background,
+    fontFamily: fontStack,
+  },
+  imagePane: {
+    display: "flex",
+    width: 540,
+    height: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: brandColors.surfaceMuted,
+    position: "relative",
+    overflow: "hidden",
+  },
+  imageGlow: {
+    position: "absolute",
+    top: -180,
+    left: -180,
+    width: 600,
+    height: 600,
+    borderRadius: 600,
+    background: `radial-gradient(circle, ${brandColors.secondary}33 0%, transparent 70%)`,
+    display: "flex",
+  },
+  productImage: {
+    display: "flex",
+    width: "92%",
+    height: "92%",
+    objectFit: "contain" as const,
+    zIndex: 1,
+  },
+  imagePlaceholder: {
+    display: "flex",
+    fontSize: 140,
+    color: brandColors.secondary,
+    zIndex: 1,
+  },
+  infoPane: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    padding: "56px 60px",
+    backgroundColor: brandColors.background,
+  },
+  headerRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 36,
+  },
+  pillRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 18,
+    flexShrink: 0,
+  },
+  categoryPill: {
+    display: "flex",
+    padding: "8px 18px",
+    backgroundColor: brandColors.secondary,
+    color: brandColors.background,
+    fontSize: 22,
+    fontWeight: 600,
+    borderRadius: 999,
+    marginRight: 12,
+  },
+  brandPill: {
+    display: "flex",
+    padding: "8px 18px",
+    backgroundColor: "transparent",
+    border: `2px solid ${brandColors.surfaceMuted}`,
+    color: brandColors.muted,
+    fontSize: 22,
+    fontWeight: 600,
+    borderRadius: 999,
+  },
+  productName: {
+    display: "flex",
+    fontSize: 54,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: brandColors.foreground,
+    lineHeight: 1.1,
+    marginBottom: 22,
+    flexShrink: 0,
+    maxHeight: 144,
+    overflow: "hidden",
+  },
+  description: {
+    display: "flex",
+    fontSize: 24,
+    color: brandColors.muted,
+    lineHeight: 1.4,
+    marginBottom: 28,
+    flexShrink: 0,
+    maxHeight: 138,
+    overflow: "hidden",
+  },
+  priceRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "baseline",
+    marginBottom: 12,
+    flexShrink: 0,
+  },
+  priceMain: {
+    display: "flex",
+    fontSize: 60,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: brandColors.secondary,
+    marginRight: 18,
+  },
+  priceCompare: {
+    display: "flex",
+    fontSize: 30,
+    color: brandColors.mutedSubtle,
+    textDecoration: "line-through",
+  },
+  footerRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: "auto",
+    paddingTop: 28,
+    borderTop: `1px solid ${brandColors.surfaceMuted}`,
+  },
+  stockBadgeOK: {
+    display: "flex",
+    padding: "8px 18px",
+    backgroundColor: `${brandColors.success}26`,
+    color: brandColors.success,
+    fontSize: 22,
+    fontWeight: 600,
+    borderRadius: 999,
+  },
+  stockBadgeOut: {
+    display: "flex",
+    padding: "8px 18px",
+    backgroundColor: `${brandColors.danger}26`,
+    color: brandColors.danger,
+    fontSize: 22,
+    fontWeight: 600,
+    borderRadius: 999,
+  },
+};
+
+export function ProductOGTemplate({
+  name,
+  description,
+  price,
+  comparePrice,
+  category,
+  brand,
+  inStock,
+  imageUrl,
+}: ProductTemplateProps) {
+  return (
+    <div style={productStyles.root}>
+      {/* Image pane */}
+      <div style={productStyles.imagePane}>
+        <div style={productStyles.imageGlow} />
+        {imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={imageUrl} alt="" style={productStyles.productImage} />
+        ) : (
+          <div style={productStyles.imagePlaceholder}>✨</div>
         )}
+      </div>
+
+      {/* Info pane */}
+      <div style={productStyles.infoPane}>
+        <div style={productStyles.headerRow}>
+          <Wordmark size={32} />
+        </div>
+
+        {(category || brand) && (
+          <div style={productStyles.pillRow}>
+            {category && <div style={productStyles.categoryPill}>{category}</div>}
+            {brand && <div style={productStyles.brandPill}>{brand}</div>}
+          </div>
+        )}
+
+        <div style={productStyles.productName}>{name}</div>
+
+        {description && <div style={productStyles.description}>{description}</div>}
+
+        <div style={productStyles.priceRow}>
+          <div style={productStyles.priceMain}>{price}</div>
+          {comparePrice && <div style={productStyles.priceCompare}>{comparePrice}</div>}
+        </div>
+
+        <div style={productStyles.footerRow}>
+          <div style={inStock ? productStyles.stockBadgeOK : productStyles.stockBadgeOut}>
+            {inStock ? "In Stock" : "Out of Stock"}
+          </div>
+          <LocationStrip />
+        </div>
       </div>
     </div>
   );
 }
 
-/**
- * Product OG Template
- */
-export function ProductOGTemplate({
-  name,
-  description,
-  price,
-  category,
-  inStock,
-}: {
+/* -------------------------------------------------------------------------- */
+/*  Service template — single hero panel, no per-package image available.     */
+/* -------------------------------------------------------------------------- */
+
+interface ServiceTemplateProps {
   name: string;
   description: string;
-  price: string;
-  category?: string;
-  inStock: boolean;
-}) {
-  return (
-    <BaseOGTemplate
-      title={name}
-      description={description}
-      badge={category || 'Beauty Product'}
-      price={price}
-    />
-  );
+  packageType?: string;
+  startingPrice?: string;
+  durationLabel?: string;
 }
 
-/**
- * Service OG Template
- */
+const serviceStyles: Record<string, CSSProperties> = {
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+    height: "100%",
+    padding: 60,
+    backgroundColor: brandColors.background,
+    fontFamily: fontStack,
+    position: "relative",
+    overflow: "hidden",
+  },
+  glow: {
+    position: "absolute",
+    top: -200,
+    right: -180,
+    width: 720,
+    height: 720,
+    borderRadius: 720,
+    background: `radial-gradient(circle, ${brandColors.secondary}33 0%, transparent 65%)`,
+    display: "flex",
+  },
+  glowBL: {
+    position: "absolute",
+    bottom: -260,
+    left: -240,
+    width: 720,
+    height: 720,
+    borderRadius: 720,
+    background: `radial-gradient(circle, ${brandColors.secondaryDeep}22 0%, transparent 65%)`,
+    display: "flex",
+  },
+  headerRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 24,
+    zIndex: 1,
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    justifyContent: "center",
+    zIndex: 1,
+  },
+  badge: {
+    display: "flex",
+    padding: "10px 22px",
+    backgroundColor: brandColors.secondary,
+    color: brandColors.background,
+    fontSize: 26,
+    fontWeight: 600,
+    borderRadius: 999,
+    alignSelf: "flex-start",
+    marginBottom: 22,
+    flexShrink: 0,
+  },
+  title: {
+    display: "flex",
+    fontSize: 72,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: brandColors.foreground,
+    lineHeight: 1.1,
+    marginBottom: 26,
+    maxWidth: 1000,
+    flexShrink: 0,
+  },
+  description: {
+    display: "flex",
+    fontSize: 28,
+    color: brandColors.muted,
+    lineHeight: 1.4,
+    marginBottom: 30,
+    maxWidth: 980,
+    flexShrink: 0,
+    maxHeight: 160,
+    overflow: "hidden",
+  },
+  priceRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "baseline",
+    flexShrink: 0,
+  },
+  priceLabel: {
+    display: "flex",
+    fontSize: 26,
+    color: brandColors.mutedSubtle,
+    marginRight: 14,
+  },
+  priceValue: {
+    display: "flex",
+    fontSize: 72,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: brandColors.secondary,
+  },
+  footer: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: "auto",
+    paddingTop: 28,
+    borderTop: `1px solid ${brandColors.surfaceMuted}`,
+    zIndex: 1,
+  },
+  durationPill: {
+    display: "flex",
+    padding: "8px 18px",
+    backgroundColor: brandColors.surfaceMuted,
+    color: brandColors.muted,
+    fontSize: 22,
+    fontWeight: 600,
+    borderRadius: 999,
+  },
+};
+
 export function ServiceOGTemplate({
   name,
   description,
   packageType,
-  basePrice,
-}: {
-  name: string;
-  description: string;
-  packageType: string;
-  basePrice?: string;
-}) {
+  startingPrice,
+  durationLabel,
+}: ServiceTemplateProps) {
   return (
-    <BaseOGTemplate
-      title={name}
-      description={description}
-      badge={packageType}
-      price={basePrice}
-    />
+    <div style={serviceStyles.root}>
+      <div style={serviceStyles.glow} />
+      <div style={serviceStyles.glowBL} />
+
+      <div style={serviceStyles.headerRow}>
+        <Wordmark size={36} />
+      </div>
+
+      <div style={serviceStyles.body}>
+        {packageType && <div style={serviceStyles.badge}>{packageType}</div>}
+        <div style={serviceStyles.title}>{name}</div>
+        {description && <div style={serviceStyles.description}>{description}</div>}
+        {startingPrice && (
+          <div style={serviceStyles.priceRow}>
+            <div style={serviceStyles.priceLabel}>from</div>
+            <div style={serviceStyles.priceValue}>{startingPrice}</div>
+          </div>
+        )}
+      </div>
+
+      <div style={serviceStyles.footer}>
+        {durationLabel ? <div style={serviceStyles.durationPill}>{durationLabel}</div> : <div />}
+        <LocationStrip />
+      </div>
+    </div>
   );
 }
 
-/**
- * Homepage OG Template
- */
+/* -------------------------------------------------------------------------- */
+/*  Generic / homepage / page-level fallback                                  */
+/* -------------------------------------------------------------------------- */
+
+interface BaseTemplateProps {
+  title: string;
+  description?: string;
+  badge?: string;
+}
+
+const baseStyles: Record<string, CSSProperties> = {
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+    height: "100%",
+    padding: 60,
+    backgroundColor: brandColors.background,
+    fontFamily: fontStack,
+    position: "relative",
+    overflow: "hidden",
+  },
+  glow: {
+    position: "absolute",
+    top: -200,
+    right: -160,
+    width: 640,
+    height: 640,
+    borderRadius: 640,
+    background: `radial-gradient(circle, ${brandColors.secondary}33 0%, transparent 65%)`,
+    display: "flex",
+  },
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 36,
+    zIndex: 1,
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    justifyContent: "center",
+    zIndex: 1,
+    maxWidth: 1000,
+  },
+  badge: {
+    display: "flex",
+    padding: "10px 22px",
+    backgroundColor: brandColors.secondary,
+    color: brandColors.background,
+    fontSize: 24,
+    fontWeight: 600,
+    borderRadius: 999,
+    alignSelf: "flex-start",
+    marginBottom: 22,
+  },
+  title: {
+    display: "flex",
+    fontSize: 68,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: brandColors.foreground,
+    lineHeight: 1.1,
+    marginBottom: 26,
+    flexShrink: 0,
+  },
+  description: {
+    display: "flex",
+    fontSize: 30,
+    color: brandColors.muted,
+    lineHeight: 1.4,
+    flexShrink: 0,
+  },
+  footer: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: "auto",
+    paddingTop: 28,
+    borderTop: `1px solid ${brandColors.surfaceMuted}`,
+    zIndex: 1,
+  },
+};
+
+export function BaseOGTemplate({ title, description, badge }: BaseTemplateProps) {
+  return (
+    <div style={baseStyles.root}>
+      <div style={baseStyles.glow} />
+      <div style={baseStyles.header}>
+        <Wordmark size={40} />
+      </div>
+      <div style={baseStyles.body}>
+        {badge && <div style={baseStyles.badge}>{badge}</div>}
+        <div style={baseStyles.title}>{title}</div>
+        {description && <div style={baseStyles.description}>{description}</div>}
+      </div>
+      <div style={baseStyles.footer}>
+        <LocationStrip />
+      </div>
+    </div>
+  );
+}
+
 export function HomepageOGTemplate() {
   return (
     <BaseOGTemplate
       title="Premier Makeup Artistry & Beauty Services"
-      description="Professional makeup, beauty products, and comprehensive salon services in Kitui and Nairobi, Kenya"
+      description="Professional makeup, beauty products, and bridal services in Kitui and Nairobi, Kenya."
       badge="✨ Glam by Lynn"
     />
   );
 }
 
-/**
- * Generic Page OG Template
- */
 export function GenericPageOGTemplate({
   title,
   description,


### PR DESCRIPTION
## Summary
- Product OG/Twitter cards now render with a split layout — primary product image on the left, brand wordmark + category/brand pills + product name + sentence-trimmed description + price (with compare-at when discounted) + In Stock / Out of Stock badge on the right. Fallback sparkle for products without an image; "Product not available" card on 404.
- Services OG now fetches the live catalogue and quotes a real "from KSh X" starting price; falls back gracefully if the API is unreachable.
- New server layout under `/products/[id]` emits the per-product `<meta>` tags WhatsApp / Facebook / LinkedIn / Twitter need for the textual half of the preview: `og:title`, `og:description`, `og:image`, `og:url`, `twitter:card`, `product:price:amount`, `product:price:currency=KES`, `product:availability`, `product:brand`, `product:category`, plus `alternates.canonical`.
- Twitter image route is now a thin re-export of the OG generator so artwork stays in sync between Twitter, WhatsApp, and Facebook.
- Latent fix: the old code called `.toLocaleString()` on `Decimal` prices that arrive as strings — silently produced no formatting. Also awaits Next.js 16's `Promise<params>` signature in `opengraph-image.tsx`.

## Test plan
- [ ] `GET /products/{id}` renders 200 and the HTML includes `og:title`, `og:description`, `og:image`, `product:price:amount`, `product:availability` meta tags.
- [ ] `GET /products/{id}/opengraph-image` returns a 1200×630 PNG with category, product name, trimmed description, price, and stock badge — no text overlap.
- [ ] `GET /products/{id}/twitter-image` returns the identical PNG (no drift).
- [ ] `GET /services/opengraph-image` returns a 1200×630 PNG that quotes the lowest active package price.
- [ ] Paste a product URL into WhatsApp / Facebook — preview shows the image plus title and description.
- [ ] Use the Facebook Sharing Debugger and Twitter Card Validator after deploy to confirm crawler unfurl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)