### PR TITLE
fix(og): inline route-segment config and tighten params typing

### DIFF
--- a/frontend/src/app/products/[id]/layout.tsx
+++ b/frontend/src/app/products/[id]/layout.tsx
@@ -37,10 +37,10 @@ function formatKsh(raw: string | number | undefined | null): string | null {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ id: string }> | { id: string };
+  params: Promise<{ id: string }>;
 }): Promise<Metadata> {
-  const resolved = await params;
-  const product = await getProduct(resolved.id);
+  const { id } = await params;
+  const product = await getProduct(id);
 
   if (!product) {
     return {

--- a/frontend/src/app/products/[id]/twitter-image.tsx
+++ b/frontend/src/app/products/[id]/twitter-image.tsx
@@ -2,8 +2,17 @@
  * Product Detail Twitter Card Image
  *
  * Same artwork as the OpenGraph image so X / Twitter previews stay
- * consistent with WhatsApp, Facebook, and LinkedIn.
+ * consistent with WhatsApp, Facebook, and LinkedIn. Route segment config
+ * is declared here directly because Next.js must statically parse it
+ * (re-exports break the build).
  */
 
-export { default } from "./opengraph-image";
-export { runtime, alt, size, contentType } from "./opengraph-image";
+import { OG_SIZE } from "@/lib/og-templates";
+import OpenGraphImage from "./opengraph-image";
+
+export const runtime = "edge";
+export const alt = "Product - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default OpenGraphImage;

--- a/frontend/src/app/services/twitter-image.tsx
+++ b/frontend/src/app/services/twitter-image.tsx
@@ -1,2 +1,15 @@
-export { default } from "./opengraph-image";
-export { runtime, alt, size, contentType } from "./opengraph-image";
+/**
+ * Services Twitter Card Image — same artwork as the OG image. Route
+ * segment config must be declared directly (re-exports cannot be
+ * statically parsed by Next.js).
+ */
+
+import { OG_SIZE } from "@/lib/og-templates";
+import OpenGraphImage from "./opengraph-image";
+
+export const runtime = "edge";
+export const alt = "Makeup Services - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default OpenGraphImage;


### PR DESCRIPTION
## Summary
Vercel build was failing on the twitter-image routes because Next.js requires `runtime` / `size` / `alt` / `contentType` to be statically parsable in the source file — re-exporting them through another module isn't allowed. Each `twitter-image.tsx` now declares these directly and only the default `Image` function is shared with the OG generator.

Same patch tightens `/products/[id]/layout.tsx` `generateMetadata` params to `Promise<{ id: string }>` (Next.js 16's `LayoutProps` rejects the union we had).

Verified locally with `next build` — production build now compiles and the route map shows all OG/twitter routes registered as dynamic edge functions.

## Test plan
- [ ] Vercel build succeeds on this PR's preview.
- [ ] Preview product URL: WhatsApp / Facebook Sharing Debugger unfurl shows image + title + description.
- [ ] `GET /products/{id}/twitter-image` and `/services/twitter-image` return the OG-identical PNG on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)