### PR TITLE
feat(services): shareable service detail pages with OG previews

### DIFF
--- a/backend/app/routers/whatsapp.py
+++ b/backend/app/routers/whatsapp.py
@@ -75,9 +75,8 @@ def _product_url(product: Product) -> str:
 
 
 def _service_url(pkg: ServicePackage) -> str:
-    # No per-service detail page exists; deep-link the booking wizard with the
-    # package pre-selected so the recipient lands on the right context.
-    return f"{_site_base_url()}/bookings/new?packageId={pkg.id}"
+    # Public detail page — also the canonical URL used for social previews.
+    return f"{_site_base_url()}/services/{pkg.id}"
 
 
 def _service_starting_price(pkg: ServicePackage) -> Optional[Decimal]:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -350,7 +350,18 @@ export default function Home() {
               <div className="grid gap-8 md:grid-cols-3">
                 {featuredServices.map((service, index) => (
                   <FadeInSection key={service.id} direction="up" delay={0.2 + index * 0.1} className="h-full">
-                    <Card className="group relative flex h-full flex-col overflow-hidden transition-all hover:shadow-xl hover:border-secondary/50">
+                    <Card
+                      onClick={() => router.push(`/services/${service.id}`)}
+                      role="link"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          router.push(`/services/${service.id}`);
+                        }
+                      }}
+                      className="group relative flex h-full flex-col overflow-hidden transition-all hover:shadow-xl hover:border-secondary/50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+                    >
                     <div className="absolute right-0 top-0 h-32 w-32 bg-gradient-to-br from-secondary/10 to-transparent rounded-bl-full" />
                     <CardHeader className="relative">
                       <CardTitle className="text-xl mb-2">{service.name}</CardTitle>
@@ -393,17 +404,32 @@ export default function Home() {
                         )}
                       </div>
 
-                      <Button asChild className="mt-auto w-full bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70 active:text-secondary-foreground">
-                        <Link href={`/bookings/new?packageId=${service.id}`}>
-                          Book Now
-                          <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-                        </Link>
-                      </Button>
-                      <WhatsAppButton
-                        variant="outline"
-                        label="Book on WhatsApp"
-                        context={{ type: "service", service_id: service.id }}
-                      />
+                      <div className="mt-auto space-y-2" onClick={(e) => e.stopPropagation()}>
+                        <div className="grid grid-cols-2 gap-2">
+                          <Button
+                            asChild
+                            className="bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70 active:text-secondary-foreground"
+                          >
+                            <Link href={`/bookings/new?packageId=${service.id}`}>
+                              Book Now
+                              <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                            </Link>
+                          </Button>
+                          <Button
+                            asChild
+                            variant="outline"
+                            className="border-secondary text-secondary hover:bg-secondary/10 hover:text-secondary"
+                          >
+                            <Link href={`/services/${service.id}`}>View Details</Link>
+                          </Button>
+                        </div>
+                        <WhatsAppButton
+                          variant="outline"
+                          label="Book on WhatsApp"
+                          className="w-full"
+                          context={{ type: "service", service_id: service.id }}
+                        />
+                      </div>
                     </CardContent>
                     </Card>
                   </FadeInSection>

--- a/frontend/src/app/services/[id]/layout.tsx
+++ b/frontend/src/app/services/[id]/layout.tsx
@@ -1,0 +1,111 @@
+/**
+ * Service detail server layout — owns the per-service `<meta>` tags so
+ * social previews unfurl with real title/description/starting price next
+ * to the auto-generated OpenGraph image. The page body is the client
+ * component in `./page.tsx`.
+ */
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import { siteConfig } from "@/lib/metadata";
+import { trimDescription } from "@/lib/og-templates";
+import { getPackageTypeName } from "@/lib/services";
+import type { ServicePackage } from "@/types";
+
+async function getService(id: string): Promise<ServicePackage | null> {
+  try {
+    const res = await fetch(
+      `${API_BASE_URL}${API_ENDPOINTS.SERVICES.DETAIL(id)}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as ServicePackage;
+  } catch (error) {
+    console.error("metadata service fetch failed", error);
+    return null;
+  }
+}
+
+function startingPrice(pkg: ServicePackage): number | null {
+  const candidates = [
+    pkg.base_bride_price,
+    pkg.base_maid_price,
+    pkg.base_mother_price,
+    pkg.base_other_price,
+  ]
+    .map((p) => (p ? Number.parseFloat(p) : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return candidates.length ? Math.min(...candidates) : null;
+}
+
+function formatKsh(n: number): string {
+  return `KSh ${Math.round(n).toLocaleString("en-KE")}`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const pkg = await getService(id);
+
+  if (!pkg) {
+    return {
+      title: "Service not available",
+      description:
+        "This service may have been removed. Browse all Glam by Lynn service packages.",
+      robots: { index: false, follow: true },
+    };
+  }
+
+  const price = startingPrice(pkg);
+  const priceLine = price !== null ? `From ${formatKsh(price)}.` : null;
+  const trimmedDesc = trimDescription(pkg.description, 160);
+  const description = [
+    priceLine,
+    trimmedDesc || "Professional makeup service from Glam by Lynn.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const canonical = `${siteConfig.url}/services/${pkg.id}`;
+  const title = `${pkg.name} — ${getPackageTypeName(pkg.package_type)}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      title,
+      description,
+      url: canonical,
+      siteName: siteConfig.name,
+      locale: "en_KE",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      creator: "@glambylynn",
+    },
+    other: {
+      ...(price !== null
+        ? {
+            "og:price:amount": String(price),
+            "og:price:currency": "KES",
+            "product:price:amount": String(price),
+            "product:price:currency": "KES",
+          }
+        : {}),
+      "product:category": getPackageTypeName(pkg.package_type),
+    },
+  };
+}
+
+export default function ServiceLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/services/[id]/opengraph-image.tsx
+++ b/frontend/src/app/services/[id]/opengraph-image.tsx
@@ -1,0 +1,102 @@
+/**
+ * Service Detail OpenGraph Image
+ *
+ * Renders a 1200×630 social preview with the service name, type badge,
+ * starting price, and a sentence-trimmed description.
+ */
+
+import { ImageResponse } from "@vercel/og";
+
+import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
+import {
+  OG_SIZE,
+  ServiceOGTemplate,
+  GenericPageOGTemplate,
+  trimDescription,
+} from "@/lib/og-templates";
+import { getPackageTypeName } from "@/lib/services";
+import type { ServicePackage } from "@/types";
+
+export const runtime = "edge";
+export const alt = "Service - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+async function getService(id: string): Promise<ServicePackage | null> {
+  try {
+    const res = await fetch(
+      `${API_BASE_URL}${API_ENDPOINTS.SERVICES.DETAIL(id)}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as ServicePackage;
+  } catch (error) {
+    console.error("OG service fetch failed", error);
+    return null;
+  }
+}
+
+function startingPrice(pkg: ServicePackage): number | null {
+  const candidates = [
+    pkg.base_bride_price,
+    pkg.base_maid_price,
+    pkg.base_mother_price,
+    pkg.base_other_price,
+  ]
+    .map((p) => (p ? Number.parseFloat(p) : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return candidates.length ? Math.min(...candidates) : null;
+}
+
+function formatKsh(n: number): string {
+  return `KSh ${Math.round(n).toLocaleString("en-KE")}`;
+}
+
+function durationLabel(pkg: ServicePackage): string | undefined {
+  if (!pkg.duration_minutes) return undefined;
+  const m = pkg.duration_minutes;
+  if (m >= 1440) {
+    const days = Math.floor(m / 1440);
+    return `${days} day${days > 1 ? "s" : ""}`;
+  }
+  const hours = Math.floor(m / 60);
+  const minutes = m % 60;
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}min`;
+  if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""}`;
+  return `${minutes} min`;
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const pkg = await getService(id);
+
+  if (!pkg) {
+    return new ImageResponse(
+      (
+        <GenericPageOGTemplate
+          title="Service not available"
+          description="This service may have been removed. Browse the full Glam by Lynn catalogue at glambylynn.com."
+        />
+      ),
+      { ...size },
+    );
+  }
+
+  const price = startingPrice(pkg);
+  return new ImageResponse(
+    (
+      <ServiceOGTemplate
+        name={pkg.name}
+        description={trimDescription(pkg.description, 180)}
+        packageType={getPackageTypeName(pkg.package_type)}
+        startingPrice={price !== null ? formatKsh(price) : undefined}
+        durationLabel={durationLabel(pkg)}
+      />
+    ),
+    { ...size },
+  );
+}

--- a/frontend/src/app/services/[id]/page.tsx
+++ b/frontend/src/app/services/[id]/page.tsx
@@ -1,0 +1,233 @@
+/**
+ * Service Detail Page
+ *
+ * Public detail view for a single service package. This is the URL we
+ * share on socials (replaces the previous deep-link to /bookings/new),
+ * so the OG layout + this page must stay in sync.
+ */
+
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertCircle, ArrowLeft, CalendarCheck, Sparkles } from "lucide-react";
+
+import {
+  getServicePackageById,
+  getPackageTypeName,
+  getPricingDescription,
+  getPackageFeatures,
+  formatPrice,
+} from "@/lib/services";
+import type { ServicePackage } from "@/types";
+
+interface ServiceDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+function startingPrice(pkg: ServicePackage): string | null {
+  const candidates = [
+    pkg.base_bride_price,
+    pkg.base_maid_price,
+    pkg.base_mother_price,
+    pkg.base_other_price,
+  ]
+    .map((p) => (p ? Number.parseFloat(p) : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  if (!candidates.length) return null;
+  return formatPrice(Math.min(...candidates));
+}
+
+export default function ServiceDetailPage({ params }: ServiceDetailPageProps) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [pkg, setPkg] = useState<ServicePackage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getServicePackageById(id)
+      .then((data) => {
+        if (!cancelled) setPkg(data);
+      })
+      .catch((err) => {
+        console.error("service fetch failed", err);
+        if (!cancelled) setError("Failed to load service details. Please try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <main className="container mx-auto px-4 py-8">
+          <Skeleton className="mb-4 h-10 w-32" />
+          <div className="grid gap-8 lg:grid-cols-3">
+            <div className="space-y-4 lg:col-span-2">
+              <Skeleton className="h-10 w-2/3" />
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-48 w-full" />
+            </div>
+            <Skeleton className="h-72 w-full" />
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (error || !pkg) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <main className="container mx-auto px-4 py-8">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-6">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back
+          </Button>
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-16">
+              <AlertCircle className="mb-4 h-12 w-12 text-muted-foreground" />
+              <p className="mb-4 text-lg font-medium">
+                {error || "Service not found"}
+              </p>
+              <Button onClick={() => router.push("/services")}>
+                Browse All Services
+              </Button>
+            </CardContent>
+          </Card>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const features = getPackageFeatures(pkg);
+  const pricing = getPricingDescription(pkg);
+  const startsAt = startingPrice(pkg);
+  const isPopular =
+    pkg.package_type === "bridal_large" || pkg.package_type === "bride_only";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main className="container mx-auto px-4 py-8">
+        <Button variant="ghost" onClick={() => router.push("/services")} className="mb-6">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Services
+        </Button>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          {/* Main column */}
+          <div className="space-y-8 lg:col-span-2">
+            <div>
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">
+                  {getPackageTypeName(pkg.package_type)}
+                </Badge>
+                {isPopular && (
+                  <Badge>
+                    <Sparkles className="mr-1 h-3 w-3" /> Popular
+                  </Badge>
+                )}
+                {pkg.includes_facial && (
+                  <Badge variant="outline">Facial included</Badge>
+                )}
+              </div>
+              <h1 className="text-4xl font-bold tracking-tight">{pkg.name}</h1>
+              {startsAt && (
+                <p className="mt-3 text-2xl font-semibold text-secondary">
+                  From {startsAt}
+                </p>
+              )}
+            </div>
+
+            {pkg.description && (
+              <div>
+                <h2 className="mb-2 text-lg font-semibold">About this service</h2>
+                <p className="text-muted-foreground whitespace-pre-line">
+                  {pkg.description}
+                </p>
+              </div>
+            )}
+
+            <div>
+              <h2 className="mb-3 text-lg font-semibold">What&apos;s included</h2>
+              <ul className="grid gap-2 sm:grid-cols-2">
+                {features.map((feature, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-start gap-2 text-sm text-muted-foreground"
+                  >
+                    <span className="mt-1 text-secondary">✓</span>
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h2 className="mb-3 text-lg font-semibold">Pricing</h2>
+              <p className="text-sm text-muted-foreground">{pricing}</p>
+            </div>
+          </div>
+
+          {/* Booking sidebar */}
+          <aside className="lg:sticky lg:top-24 lg:self-start">
+            <Card className="border-secondary/40 shadow-lg">
+              <CardHeader>
+                <CardTitle>Ready to book?</CardTitle>
+                <CardDescription>
+                  Reserve this package or start the conversation on WhatsApp.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Button
+                  className="w-full"
+                  size="lg"
+                  onClick={() => router.push(`/bookings/new?packageId=${pkg.id}`)}
+                >
+                  <CalendarCheck className="mr-2 h-5 w-5" />
+                  Book Now
+                </Button>
+                <WhatsAppButton
+                  variant="outline"
+                  size="lg"
+                  label="Book on WhatsApp"
+                  className="w-full"
+                  context={{ type: "service", service_id: pkg.id }}
+                />
+              </CardContent>
+            </Card>
+          </aside>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/app/services/[id]/twitter-image.tsx
+++ b/frontend/src/app/services/[id]/twitter-image.tsx
@@ -1,0 +1,15 @@
+/**
+ * Service Detail Twitter Card Image — reuses the OG artwork. Route segment
+ * config is declared here directly because Next.js must statically parse
+ * it (re-exports break the build).
+ */
+
+import { OG_SIZE } from "@/lib/og-templates";
+import OpenGraphImage from "./opengraph-image";
+
+export const runtime = "edge";
+export const alt = "Service - Glam by Lynn";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default OpenGraphImage;

--- a/frontend/src/app/services/page.tsx
+++ b/frontend/src/app/services/page.tsx
@@ -46,8 +46,11 @@ export default function ServicesPage() {
   }, []);
 
   const handleBookNow = (packageId: string) => {
-    // TODO: Navigate to booking form with package pre-selected
     router.push(`/bookings/new?packageId=${packageId}`);
+  };
+
+  const handleViewDetails = (packageId: string) => {
+    router.push(`/services/${packageId}`);
   };
 
   return (
@@ -103,7 +106,16 @@ export default function ServicesPage() {
                     key={pkg.id}
                     id={pkg.id}
                     data-testid="service-card"
-                    className={`flex h-full flex-col ${isPopular ? "service-card package-card border-secondary shadow-lg" : "service-card package-card"}`}
+                    onClick={() => handleViewDetails(pkg.id)}
+                    role="link"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleViewDetails(pkg.id);
+                      }
+                    }}
+                    className={`flex h-full flex-col cursor-pointer transition-all hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${isPopular ? "service-card package-card border-secondary shadow-lg" : "service-card package-card"}`}
                   >
                     <CardHeader>
                       <div className="flex items-start justify-between">
@@ -140,18 +152,29 @@ export default function ServicesPage() {
                           <p className="text-sm text-muted-foreground">Pricing</p>
                           <p className="text-sm font-semibold">{pricingDescription}</p>
                         </div>
-                        <Button
-                          onClick={() => handleBookNow(pkg.id)}
-                          className="w-full"
-                        >
-                          Book Now
-                        </Button>
-                        <WhatsAppButton
-                          variant="outline"
-                          label="Book on WhatsApp"
-                          className="w-full"
-                          context={{ type: "service", service_id: pkg.id }}
-                        />
+                        <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
+                          <div className="grid grid-cols-2 gap-2">
+                            <Button
+                              onClick={() => handleBookNow(pkg.id)}
+                              className="bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70 active:text-secondary-foreground"
+                            >
+                              Book Now
+                            </Button>
+                            <Button
+                              variant="outline"
+                              onClick={() => handleViewDetails(pkg.id)}
+                              className="border-secondary text-secondary hover:bg-secondary/10 hover:text-secondary"
+                            >
+                              View Details
+                            </Button>
+                          </div>
+                          <WhatsAppButton
+                            variant="outline"
+                            label="Book on WhatsApp"
+                            className="w-full"
+                            context={{ type: "service", service_id: pkg.id }}
+                          />
+                        </div>
                       </div>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## Summary
- New `/services/[id]` route with detail page, server-rendered metadata, and dynamic OpenGraph + Twitter card images so shared service links unfurl with name, type, starting price, and trimmed description.
- Backend WhatsApp service deep-link (`_service_url`) now points to `/services/{id}` instead of `/bookings/new?packageId=...`, so the URL embedded in service WhatsApp messages opens the new shareable page.
- Featured service cards on the homepage and the `/services` listing are now clickable (mouse + keyboard) with a consistent CTA hierarchy: solid pink **Book Now** + pink-outline **View Details** side by side, full-width **Book on WhatsApp** below.

## Test plan
- [ ] `/services/<id>` renders the new detail page with hero, what's-included, pricing, and booking sidebar
- [ ] `/services/<id>/opengraph-image` and `/twitter-image` return a 1200×630 PNG with name, type badge, starting price, duration
- [ ] `<meta>` tags include `og:title`, `og:description`, `og:image`, `twitter:card=summary_large_image`, `og:price:amount` / `og:price:currency=KES`
- [ ] `POST /api/whatsapp/link {"type":"service",...}` embeds `…/services/<id>` in the prefilled message
- [ ] Clicking a service card (or pressing Enter / Space) on `/` and `/services` navigates to the detail page
- [ ] Button clicks (Book Now / View Details / Book on WhatsApp) do not bubble to the card-click handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)