### PR TITLE
feat(bookings): guest-first booking flow with shareable confirmation

### DIFF
--- a/backend/alembic/versions/e5f6a7b8c9d0_relax_booking_location_to_address_only.py
+++ b/backend/alembic/versions/e5f6a7b8c9d0_relax_booking_location_to_address_only.py
@@ -1,0 +1,56 @@
+"""relax booking location to address + description only
+
+Bookings no longer require a predefined location_id or full Mapbox
+lat/lng/distance. The address (search result) is what we keep; an
+optional `location_description` lets the customer add directions or
+landmarks. Transport cost is computed manually after the booking is
+placed, so the old check constraint that required full coordinates is
+replaced with a simpler "address is set" check.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-05-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bookings",
+        sa.Column("location_description", sa.Text(), nullable=True),
+    )
+    # The legacy constraint may or may not exist depending on how the DB
+    # was originally provisioned — drop defensively.
+    op.execute(
+        "ALTER TABLE bookings DROP CONSTRAINT IF EXISTS bookings_location_check"
+    )
+    op.create_check_constraint(
+        "bookings_location_check",
+        "bookings",
+        "location_id IS NOT NULL OR custom_location_address IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("bookings_location_check", "bookings", type_="check")
+    op.create_check_constraint(
+        "bookings_location_check",
+        "bookings",
+        """
+        location_id IS NOT NULL OR
+        (custom_location_address IS NOT NULL AND
+         custom_location_latitude IS NOT NULL AND
+         custom_location_longitude IS NOT NULL AND
+         custom_location_distance_km IS NOT NULL)
+        """,
+    )
+    op.drop_column("bookings", "location_description")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -74,6 +74,38 @@ def verify_token(token: str, token_type: str = "access") -> Optional[Dict[str, A
         return None
 
 
+def create_booking_confirmation_token(
+    booking_id: str, expires_in_days: int = 30
+) -> str:
+    """
+    Create a signed token that lets a guest re-open their booking
+    confirmation without an account. The token binds to a specific
+    booking_id and expires after a configurable window.
+    """
+    expire = datetime.utcnow() + timedelta(days=expires_in_days)
+    payload = {
+        "sub": str(booking_id),
+        "exp": expire,
+        "type": "booking_confirmation",
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_booking_confirmation_token(token: str) -> Optional[str]:
+    """
+    Verify a booking confirmation token and return the booking_id it
+    was issued for, or None if the token is invalid / expired / for a
+    different purpose.
+    """
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError:
+        return None
+    if payload.get("type") != "booking_confirmation":
+        return None
+    return payload.get("sub")
+
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
     Verify a password against its hash

--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -51,11 +51,17 @@ class Booking(Base):
         index=True,
     )
 
-    # Custom location fields (for locations not in transport_locations table)
-    custom_location_address = Column(Text, nullable=True)  # Full address from Mapbox
-    custom_location_latitude = Column(Float, nullable=True)  # Latitude coordinate
-    custom_location_longitude = Column(Float, nullable=True)  # Longitude coordinate
-    custom_location_distance_km = Column(Float, nullable=True)  # Distance from Nairobi in km
+    # Custom location fields (for locations not in transport_locations table).
+    # Lat/lng/distance are kept for backwards compatibility but are no longer
+    # required at booking time; transport cost is determined manually after
+    # the booking is placed.
+    custom_location_address = Column(Text, nullable=True)  # Search result text
+    custom_location_latitude = Column(Float, nullable=True)
+    custom_location_longitude = Column(Float, nullable=True)
+    custom_location_distance_km = Column(Float, nullable=True)
+    # Free-text directions / landmarks added by the customer to clarify
+    # the exact spot the artist should travel to.
+    location_description = Column(Text, nullable=True)
 
     num_brides = Column(Integer, default=1)
     num_maids = Column(Integer, default=0)
@@ -106,13 +112,7 @@ class Booking(Base):
             name="bookings_deposit_amount_check_50_percent",
         ),
         CheckConstraint(
-            """
-            location_id IS NOT NULL OR
-            (custom_location_address IS NOT NULL AND
-             custom_location_latitude IS NOT NULL AND
-             custom_location_longitude IS NOT NULL AND
-             custom_location_distance_km IS NOT NULL)
-            """,
+            "location_id IS NOT NULL OR custom_location_address IS NOT NULL",
             name="bookings_location_check",
         ),
         Index("idx_bookings_date_time", "booking_date", "booking_time"),

--- a/backend/app/routers/bookings.py
+++ b/backend/app/routers/bookings.py
@@ -10,8 +10,19 @@ from uuid import UUID
 
 from app.core.database import get_db
 from app.core.dependencies import get_optional_current_user, get_current_user
+from app.core.security import (
+    create_booking_confirmation_token,
+    verify_booking_confirmation_token,
+)
+from app.models.booking import Booking
 from app.models.user import User
-from app.schemas.booking import AvailabilityResponse, BookingCreate, BookingResponse, BookingListResponse
+from app.schemas.booking import (
+    AvailabilityResponse,
+    BookingCreate,
+    BookingCreateResponse,
+    BookingResponse,
+    BookingListResponse,
+)
 from app.services import booking_service
 import math
 
@@ -124,6 +135,36 @@ async def get_booking_availability(
     return availability
 
 
+@router.get("/{booking_id}/confirmation", response_model=BookingResponse)
+async def get_booking_confirmation(
+    booking_id: UUID,
+    token: str = Query(..., description="Signed confirmation token"),
+    db: Session = Depends(get_db),
+):
+    """
+    Public endpoint that returns a booking when the caller presents a
+    valid signed confirmation token. Lets guests re-open or share their
+    confirmation page without an account.
+
+    Returns 404 if the token is missing, invalid, expired, or bound to a
+    different booking.
+    """
+    token_sub = verify_booking_confirmation_token(token)
+    if not token_sub or token_sub != str(booking_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invalid or expired confirmation link",
+        )
+
+    booking = db.query(Booking).filter(Booking.id == booking_id).first()
+    if not booking:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Booking with ID {booking_id} not found",
+        )
+    return booking
+
+
 @router.get("/{booking_id}", response_model=BookingResponse)
 async def get_booking_details(
     booking_id: UUID,
@@ -168,7 +209,7 @@ async def get_booking_details(
     return booking
 
 
-@router.post("", response_model=BookingResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=BookingCreateResponse, status_code=status.HTTP_201_CREATED)
 async def create_booking(
     booking_data: BookingCreate,
     db: Session = Depends(get_db),
@@ -219,7 +260,11 @@ async def create_booking(
             user_id=user_id
         )
 
-        return booking
+        token = create_booking_confirmation_token(booking.id)
+        return {
+            **BookingResponse.model_validate(booking).model_dump(),
+            "confirmation_token": token,
+        }
 
     except ValueError as e:
         raise HTTPException(

--- a/backend/app/routers/whatsapp.py
+++ b/backend/app/routers/whatsapp.py
@@ -19,10 +19,12 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.dependencies import get_optional_current_user
+from app.models.booking import Booking
 from app.models.product import Product
 from app.models.service import ServicePackage
 from app.models.user import User
 from app.schemas.whatsapp import (
+    WhatsAppBookingRequest,
     WhatsAppCartRequest,
     WhatsAppGeneralRequest,
     WhatsAppLinkRequest,
@@ -178,6 +180,33 @@ def _build_general_message(user: Optional[User]) -> str:
     return "\n".join(lines)
 
 
+def _build_booking_message(
+    db: Session, req: WhatsAppBookingRequest, user: Optional[User]
+) -> str:
+    # Strip control chars and trim to a safe length before using in the
+    # message body; the lookup itself is parameterised so SQL injection
+    # is not a concern.
+    safe_number = re.sub(r"[\x00-\x1f]", "", req.booking_number).strip()[:64]
+    if not safe_number:
+        raise HTTPException(status_code=400, detail="Booking number is required")
+
+    booking = (
+        db.query(Booking).filter(Booking.booking_number == safe_number).first()
+    )
+    if not booking:
+        # Don't leak whether the number is valid — but a no-op message is
+        # unhelpful for the user, so we keep the same wording either way.
+        # The artist receiving the message can verify the number on their end.
+        pass
+
+    lines = [
+        "Hi Glam by Lynn — I'd like to follow up on my booking.",
+        f"Booking number: {safe_number}",
+    ]
+    lines.extend(_user_lines(user))
+    return "\n".join(lines)
+
+
 @router.post(
     "/link",
     response_model=WhatsAppLinkResponse,
@@ -196,6 +225,8 @@ def generate_link(
         message = _build_service_message(db, payload, current_user)
     elif isinstance(payload, WhatsAppCartRequest):
         message = _build_cart_message(db, payload, current_user)
+    elif isinstance(payload, WhatsAppBookingRequest):
+        message = _build_booking_message(db, payload, current_user)
     else:
         message = _build_general_message(current_user)
 

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -98,6 +98,15 @@ class BookingResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class BookingCreateResponse(BookingResponse):
+    """Booking response augmented with a signed confirmation token that
+    lets a guest re-open the confirmation page without authentication."""
+
+    confirmation_token: str = Field(
+        ..., description="Signed token for revisiting the confirmation page"
+    )
+
+
 class BookingListResponse(BaseModel):
     """Schema for paginated booking list response"""
     items: list[BookingResponse]

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -36,12 +36,16 @@ class BookingCreate(BaseModel):
     booking_date: date_type = Field(..., description="Booking date")
     booking_time: time_type = Field(..., description="Booking time")
 
-    # Location: Either use predefined location OR custom location (both optional, but one must be provided)
-    location_id: Optional[UUID] = Field(None, description="Predefined transport location ID")
-    custom_location_address: Optional[str] = Field(None, description="Custom location address from Mapbox")
-    custom_location_latitude: Optional[float] = Field(None, description="Custom location latitude")
-    custom_location_longitude: Optional[float] = Field(None, description="Custom location longitude")
-    custom_location_distance_km: Optional[float] = Field(None, description="Distance from Nairobi in km")
+    # Location: a free-text address (from the search field) plus an
+    # optional description for landmarks / directions. Lat/lng/distance
+    # are accepted for backwards compatibility but are no longer required
+    # — transport cost is determined manually after the booking is placed.
+    custom_location_address: str = Field(..., min_length=1, description="Searched location address")
+    location_description: Optional[str] = Field(None, description="Extra directions / landmarks")
+    location_id: Optional[UUID] = Field(None, description="Deprecated: predefined transport location ID")
+    custom_location_latitude: Optional[float] = Field(None, description="Optional latitude")
+    custom_location_longitude: Optional[float] = Field(None, description="Optional longitude")
+    custom_location_distance_km: Optional[float] = Field(None, description="Optional distance from Nairobi (km)")
 
     num_brides: int = Field(1, ge=0, description="Number of brides")
     num_maids: int = Field(0, ge=0, description="Number of maids/bridesmaids")
@@ -66,9 +70,10 @@ class BookingResponse(BaseModel):
     booking_date: date_type
     booking_time: time_type
 
-    # Location fields (can be either predefined or custom)
+    # Location fields
     location_id: Optional[UUID]
     custom_location_address: Optional[str]
+    location_description: Optional[str]
     custom_location_latitude: Optional[float]
     custom_location_longitude: Optional[float]
     custom_location_distance_km: Optional[float]

--- a/backend/app/schemas/whatsapp.py
+++ b/backend/app/schemas/whatsapp.py
@@ -31,11 +31,17 @@ class WhatsAppGeneralRequest(BaseModel):
     type: Literal["general"]
 
 
+class WhatsAppBookingRequest(BaseModel):
+    type: Literal["booking"]
+    booking_number: str = Field(..., min_length=1, max_length=64)
+
+
 WhatsAppLinkRequest = Union[
     WhatsAppProductRequest,
     WhatsAppServiceRequest,
     WhatsAppCartRequest,
     WhatsAppGeneralRequest,
+    WhatsAppBookingRequest,
 ]
 
 

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -226,38 +226,18 @@ def calculate_booking_price(
     num_maids: int,
     num_mothers: int,
     num_others: int,
-    location_id: Optional[UUID] = None,
-    custom_location_distance_km: Optional[float] = None
 ) -> tuple[Decimal, Decimal, Decimal]:
     """
-    Calculate booking pricing
+    Calculate booking pricing.
 
-    Args:
-        db: Database session
-        package_id: Service package ID
-        num_brides: Number of brides
-        num_maids: Number of maids
-        num_mothers: Number of mothers
-        num_others: Number of other attendees
-        location_id: Transport location ID (for predefined locations)
-        custom_location_distance_km: Distance from Nairobi in km (for custom locations)
-
-    Returns:
-        Tuple of (subtotal, transport_cost, total_amount)
-
-    Raises:
-        ValueError: If package not found or neither location method provided
+    Transport cost is no longer computed automatically at booking time —
+    it's determined manually once the artist has verified location and
+    availability with the customer. So this returns (subtotal, 0, subtotal).
     """
-    # Validate that either location_id or custom_location_distance_km is provided
-    if not location_id and custom_location_distance_km is None:
-        raise ValueError("Either location_id or custom_location_distance_km must be provided")
-
-    # Get package
     package = db.query(ServicePackage).filter(ServicePackage.id == package_id).first()
     if not package:
         raise ValueError(f"Service package with ID {package_id} not found")
 
-    # Calculate subtotal
     subtotal = Decimal(0)
 
     if package.base_bride_price and num_brides > 0:
@@ -272,18 +252,7 @@ def calculate_booking_price(
     if package.base_other_price and num_others > 0:
         subtotal += package.base_other_price * num_others
 
-    # Get transport cost
-    if location_id:
-        # Predefined location
-        location = db.query(TransportLocation).filter(TransportLocation.id == location_id).first()
-        if not location:
-            raise ValueError(f"Transport location with ID {location_id} not found")
-        transport_cost = location.transport_cost or Decimal(0)
-    else:
-        # Custom location - calculate from distance
-        transport_cost = calculate_transport_cost_from_distance(custom_location_distance_km)
-
-    # Calculate total
+    transport_cost = Decimal(0)
     total_amount = subtotal + transport_cost
 
     return subtotal, transport_cost, total_amount
@@ -319,29 +288,11 @@ def create_booking(
     if not package.is_active:
         raise ValueError(f"Service package '{package.name}' is not currently available")
 
-    # Validate location: Either predefined OR custom location must be provided
-    if booking_data.location_id:
-        # Validate predefined location exists and is active
-        location = db.query(TransportLocation).filter(
-            TransportLocation.id == booking_data.location_id
-        ).first()
-
-        if not location:
-            raise ValueError(f"Transport location with ID {booking_data.location_id} not found")
-
-        if not location.is_active:
-            raise ValueError(f"Transport location '{location.name}' is not currently available")
-    else:
-        # Validate custom location has all required fields
-        if not all([
-            booking_data.custom_location_address,
-            booking_data.custom_location_latitude is not None,
-            booking_data.custom_location_longitude is not None,
-            booking_data.custom_location_distance_km is not None
-        ]):
-            raise ValueError(
-                "Custom location requires address, latitude, longitude, and distance from Nairobi"
-            )
+    # Location: a searched address string is sufficient. Transport cost is
+    # determined manually after the booking is placed (admin contacts the
+    # customer to confirm availability and location).
+    if not booking_data.custom_location_address:
+        raise ValueError("Location address is required")
 
     # Validate package rules (maid count)
     if package.max_maids is not None and booking_data.num_maids > package.max_maids:
@@ -376,7 +327,7 @@ def create_booking(
                 "Guest bookings require email, name, and phone number"
             )
 
-    # Calculate pricing
+    # Calculate pricing (transport cost is added manually post-booking)
     subtotal, transport_cost, total_amount = calculate_booking_price(
         db=db,
         package_id=booking_data.package_id,
@@ -384,8 +335,6 @@ def create_booking(
         num_maids=booking_data.num_maids,
         num_mothers=booking_data.num_mothers,
         num_others=booking_data.num_others,
-        location_id=booking_data.location_id,
-        custom_location_distance_km=booking_data.custom_location_distance_km
     )
 
     # Calculate 50% deposit (round up to ensure it meets the 50% constraint)
@@ -406,6 +355,7 @@ def create_booking(
         booking_time=booking_data.booking_time,
         location_id=booking_data.location_id,
         custom_location_address=booking_data.custom_location_address,
+        location_description=booking_data.location_description,
         custom_location_latitude=booking_data.custom_location_latitude,
         custom_location_longitude=booking_data.custom_location_longitude,
         custom_location_distance_km=booking_data.custom_location_distance_km,
@@ -708,19 +658,21 @@ def admin_update_booking(
 
     # Recalculate pricing if necessary
     if recalculate_pricing:
-        subtotal, transport_cost, total_amount = calculate_booking_price(
+        subtotal, _new_transport, _new_total = calculate_booking_price(
             db=db,
             package_id=booking.package_id,
-            location_id=booking.location_id,
             num_brides=booking.num_brides,
             num_maids=booking.num_maids,
             num_mothers=booking.num_mothers,
-            num_others=booking.num_others
+            num_others=booking.num_others,
         )
+        # Preserve any transport cost the admin has already set; only the
+        # service-derived portion (subtotal) is recomputed automatically.
         booking.subtotal = subtotal
-        booking.transport_cost = transport_cost
-        booking.total_amount = total_amount
-        booking.deposit_amount = (total_amount * Decimal('0.5')).quantize(Decimal('0.01'), rounding=ROUND_UP)
+        booking.total_amount = subtotal + (booking.transport_cost or Decimal(0))
+        booking.deposit_amount = (
+            booking.total_amount * Decimal("0.5")
+        ).quantize(Decimal("0.01"), rounding=ROUND_UP)
 
     # Update other fields
     if wedding_theme is not None:

--- a/frontend/src/app/bookings/[id]/confirmation/page.tsx
+++ b/frontend/src/app/bookings/[id]/confirmation/page.tsx
@@ -6,14 +6,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
+import { WhatsAppButton } from "@/components/WhatsAppButton";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Booking } from "@/types";
-import { getBookingById, formatCurrency, formatDate, formatTime } from "@/lib/bookings";
+import {
+  getBookingById,
+  getBookingConfirmation,
+  formatCurrency,
+  formatDate,
+  formatTime,
+} from "@/lib/bookings";
 import { useAuth } from "@/hooks/useAuth";
 import {
   Loader2,
@@ -31,8 +38,10 @@ import {
 export default function BookingConfirmationPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const { session } = useAuth();
   const bookingId = params?.id as string;
+  const confirmationToken = searchParams?.get("token") ?? null;
 
   const [booking, setBooking] = useState<Booking | null>(null);
   const [loading, setLoading] = useState(true);
@@ -49,26 +58,30 @@ export default function BookingConfirmationPage() {
       try {
         setLoading(true);
 
-        // First, try to get booking data from sessionStorage (passed from creation page)
-        // This allows guest users to see confirmation without needing authentication
-        const cachedBooking = sessionStorage.getItem(`booking_${bookingId}`);
-
-        if (cachedBooking) {
-          // Use cached booking data and clear it from storage
-          const bookingData = JSON.parse(cachedBooking);
-          setBooking(bookingData);
-          sessionStorage.removeItem(`booking_${bookingId}`);
+        // Preferred: signed token in the URL. Lets guests refresh,
+        // bookmark, or share the page without losing access.
+        if (confirmationToken) {
+          const data = await getBookingConfirmation(bookingId, confirmationToken);
+          setBooking(data);
           setLoading(false);
           return;
         }
 
-        // If no cached data, try to fetch from API (requires authentication)
-        // This handles cases where authenticated users refresh or bookmark the page
-        const token = session?.accessToken;
+        // Legacy: payload cached in sessionStorage by the creation page
+        // for users on the just-created tab.
+        const cachedBooking = sessionStorage.getItem(`booking_${bookingId}`);
+        if (cachedBooking) {
+          setBooking(JSON.parse(cachedBooking));
+          setLoading(false);
+          return;
+        }
 
+        // Last resort: authenticated owner fetching their own booking.
+        const token = session?.accessToken;
         if (!token) {
-          // Guest user without cached data - can't fetch from API
-          setError("Booking confirmation not found. Please check your email for booking details.");
+          setError(
+            "Booking confirmation not found. Please open the link from your confirmation email.",
+          );
           setLoading(false);
           return;
         }
@@ -84,7 +97,7 @@ export default function BookingConfirmationPage() {
     }
 
     loadBooking();
-  }, [bookingId, session]);
+  }, [bookingId, confirmationToken, session]);
 
   if (loading) {
     return (
@@ -149,6 +162,31 @@ export default function BookingConfirmationPage() {
             <Badge variant="secondary" className="text-base font-mono">
               {booking.bookingNumber}
             </Badge>
+          </div>
+
+          {/* What happens next — surfaced immediately so the customer
+              knows exactly what to expect without having to scroll. */}
+          <div className="mx-auto mt-8 max-w-2xl rounded-2xl border-2 border-secondary bg-secondary/10 p-5 text-left">
+            <p className="text-sm font-bold uppercase tracking-wider text-secondary">
+              What happens next
+            </p>
+            <p className="mt-2 text-base font-medium">
+              We&apos;ll review your booking details and reach out by call or
+              WhatsApp to confirm your appointment and location, verify
+              availability, share the final cost (including any transport
+              charge), and walk you through how to pay the 50% deposit.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              The remaining 50% is paid on the service delivery day, before
+              the service is provided.
+            </p>
+            <div className="mt-4">
+              <WhatsAppButton
+                size="lg"
+                label="Reach us on WhatsApp"
+                context={{ type: "booking", booking_number: booking.bookingNumber }}
+              />
+            </div>
           </div>
         </div>
       </section>
@@ -264,116 +302,60 @@ export default function BookingConfirmationPage() {
                 Price Summary
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex justify-between text-sm">
-                <span className="text-muted-foreground">Subtotal:</span>
-                <span>{formatCurrency(booking.subtotal)}</span>
-              </div>
-              <div className="flex justify-between text-sm">
-                <span className="text-muted-foreground">Transport Cost:</span>
-                <span>{formatCurrency(booking.transportCost)}</span>
-              </div>
-              <div className="border-t border-border pt-3">
-                <div className="flex justify-between font-semibold">
-                  <span>Total Amount:</span>
-                  <span>{formatCurrency(booking.totalAmount)}</span>
+            <CardContent>
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">
+                    Service subtotal:
+                  </span>
+                  <span>{formatCurrency(booking.subtotal)}</span>
                 </div>
-              </div>
-              {booking.depositAmount && (
-                <div className="rounded-lg bg-secondary/10 p-4">
-                  <div className="flex justify-between">
-                    <span className="font-medium">Deposit Required (50%):</span>
-                    <span className="text-lg font-bold text-secondary">
-                      {formatCurrency(booking.depositAmount)}
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Transport:</span>
+                  {booking.transportCost && booking.transportCost > 0 ? (
+                    <span>{formatCurrency(booking.transportCost)}</span>
+                  ) : (
+                    <span className="italic text-muted-foreground">
+                      To be confirmed
                     </span>
-                  </div>
-                  {!booking.depositPaid && (
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Payment pending - See payment instructions below
-                    </p>
                   )}
                 </div>
-              )}
+                <div className="border-t border-border pt-3">
+                  <div className="flex justify-between text-lg font-semibold">
+                    <span>Service Total:</span>
+                    <span>{formatCurrency(booking.totalAmount)}</span>
+                  </div>
+                  {booking.depositAmount && (
+                    <div className="mt-2 flex justify-between text-sm">
+                      <span className="text-muted-foreground">
+                        Deposit (50% of service total):
+                      </span>
+                      <span className="font-semibold text-secondary">
+                        {formatCurrency(booking.depositAmount)}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-4 rounded-md border border-secondary/40 bg-secondary/10 p-3 text-sm text-secondary">
+                  <p className="font-semibold">How payment works</p>
+                  <ul className="mt-1 list-disc space-y-1 pl-5 text-secondary/90">
+                    <li>
+                      Transport cost will be communicated after we verify
+                      availability and your location.
+                    </li>
+                    <li>
+                      The 50% deposit is paid once that transport quote is
+                      confirmed with you.
+                    </li>
+                    <li>
+                      The remaining 50% is paid on the service delivery day,
+                      before the service is provided.
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </CardContent>
           </Card>
-
-          {/* Payment Instructions */}
-          {booking.depositAmount && !booking.depositPaid && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Payment Instructions</CardTitle>
-                <CardDescription>Complete your deposit to confirm your booking</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="rounded-lg bg-muted p-4">
-                  <h4 className="mb-2 font-semibold">M-Pesa Payment</h4>
-                  <ol className="space-y-2 text-sm">
-                    <li className="flex gap-2">
-                      <span className="font-semibold">1.</span>
-                      <span>Go to M-Pesa on your phone</span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">2.</span>
-                      <span>Select Lipa Na M-Pesa, then Pay Bill</span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">3.</span>
-                      <span>
-                        Enter Business Number: <strong>123456</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">4.</span>
-                      <span>
-                        Enter Account Number: <strong>{booking.bookingNumber}</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">5.</span>
-                      <span>
-                        Enter Amount: <strong>{formatCurrency(booking.depositAmount)}</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">6.</span>
-                      <span>Enter your M-Pesa PIN and confirm</span>
-                    </li>
-                  </ol>
-                </div>
-
-                <div className="rounded-lg border border-border p-4">
-                  <h4 className="mb-2 font-semibold">Bank Transfer</h4>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Bank:</span>
-                      <span className="font-medium">Equity Bank</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Account Name:</span>
-                      <span className="font-medium">Glam by Lynn</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Account Number:</span>
-                      <span className="font-medium">1234567890</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Reference:</span>
-                      <span className="font-medium">{booking.bookingNumber}</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm dark:bg-blue-950/20">
-                  <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
-                  <p className="text-blue-900 dark:text-blue-100">
-                    After making payment, send confirmation via WhatsApp to{" "}
-                    <strong>+254 700 000 000</strong> or email to{" "}
-                    <strong>payments@glambylynn.com</strong>
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          )}
 
           {/* Next Steps */}
           <Card>
@@ -387,9 +369,9 @@ export default function BookingConfirmationPage() {
                     1
                   </span>
                   <div>
-                    <p className="font-medium">Booking Confirmation</p>
+                    <p className="font-medium">We review your booking</p>
                     <p className="text-sm text-muted-foreground">
-                      Review your booking details and deposit payment instructions above
+                      Our team verifies the package, attendees, date, and location you submitted.
                     </p>
                   </div>
                 </li>
@@ -398,9 +380,9 @@ export default function BookingConfirmationPage() {
                     2
                   </span>
                   <div>
-                    <p className="font-medium">Make Deposit Payment</p>
+                    <p className="font-medium">We contact you to confirm</p>
                     <p className="text-sm text-muted-foreground">
-                      Pay the 50% deposit via M-Pesa or bank transfer to secure your booking
+                      We&apos;ll call or message you on WhatsApp to confirm availability, lock in the exact location, share the final cost (including any transport charge), and send instructions for the 50% deposit.
                     </p>
                   </div>
                 </li>
@@ -409,9 +391,9 @@ export default function BookingConfirmationPage() {
                     3
                   </span>
                   <div>
-                    <p className="font-medium">Service Delivery</p>
+                    <p className="font-medium">Pay the 50% deposit</p>
                     <p className="text-sm text-muted-foreground">
-                      On your appointment day, our team will arrive at your location ready to make you look stunning
+                      Pay via M-Pesa or bank transfer using the details we share. The deposit secures your booking.
                     </p>
                   </div>
                 </li>
@@ -420,9 +402,9 @@ export default function BookingConfirmationPage() {
                     4
                   </span>
                   <div>
-                    <p className="font-medium">Complete Payment</p>
+                    <p className="font-medium">Service delivery</p>
                     <p className="text-sm text-muted-foreground">
-                      Pay the remaining 50% balance after service delivery
+                      On your appointment day, our team arrives at the confirmed location ready to make you look stunning.
                     </p>
                   </div>
                 </li>
@@ -431,9 +413,9 @@ export default function BookingConfirmationPage() {
                     5
                   </span>
                   <div>
-                    <p className="font-medium">Share Your Experience</p>
+                    <p className="font-medium">Pay the remaining 50%</p>
                     <p className="text-sm text-muted-foreground">
-                      Leave a review and help others discover our services
+                      The balance is paid on the service delivery day, before the service is provided.
                     </p>
                   </div>
                 </li>

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -52,17 +52,10 @@ import {
 
 const STEPS = [
   { id: 1, label: "Choose Service", icon: Sparkles },
-  { id: 2, label: "Date & Time", icon: Calendar },
+  { id: 2, label: "Date & Location", icon: Calendar },
   { id: 3, label: "Your Details", icon: Users },
   { id: 4, label: "Review & Confirm", icon: ClipboardCheck },
 ] as const;
-
-const TIME_SLOTS = Array.from({ length: 10 }, (_, i) => {
-  const hour = 8 + i;
-  const timeStr = `${hour.toString().padStart(2, "0")}:00:00`;
-  const displayTime = `${hour > 12 ? hour - 12 : hour}:00 ${hour >= 12 ? "PM" : "AM"}`;
-  return { value: timeStr, label: displayTime };
-});
 
 function BookingFormContent() {
   const router = useRouter();
@@ -90,7 +83,6 @@ function BookingFormContent() {
     distanceKm: number;
   } | null>(null);
   const [bookingDate, setBookingDate] = useState<string>("");
-  const [bookingTime, setBookingTime] = useState<string>("");
   const [numBrides, setNumBrides] = useState<number>(1);
   const [numMaids, setNumMaids] = useState<number>(0);
   const [numMothers, setNumMothers] = useState<number>(0);
@@ -169,7 +161,7 @@ function BookingFormContent() {
       case 1:
         return !!selectedPackageId;
       case 2:
-        return !!bookingDate && !!bookingTime && hasValidLocation;
+        return !!bookingDate && hasValidLocation;
       case 3:
         return user ? true : !!(guestName && guestEmail && guestPhone);
       case 4:
@@ -183,7 +175,6 @@ function BookingFormContent() {
     selectedPackageId &&
     hasValidLocation &&
     bookingDate &&
-    bookingTime &&
     (user || (guestName && guestEmail && guestPhone)) &&
     pricing &&
     pricing.total > 0;
@@ -239,10 +230,15 @@ function BookingFormContent() {
       setSubmitting(true);
       setError(null);
 
+      // Split the datetime-local value into the date + time fields the
+      // backend expects (HH:MM → HH:MM:SS).
+      const [datePart, timePart = ""] = bookingDate.split("T");
+      const submitTime = timePart ? `${timePart}:00` : "";
+
       const bookingData = {
         package_id: selectedPackageId,
-        booking_date: bookingDate,
-        booking_time: bookingTime,
+        booking_date: datePart,
+        booking_time: submitTime,
         ...(locationType === "predefined"
           ? { location_id: selectedLocationId }
           : {
@@ -454,7 +450,7 @@ function BookingFormContent() {
                 disabled={!canProceedFromStep(1)}
                 size="lg"
               >
-                Continue to Date & Time
+                Continue to Date & Location
                 <ChevronRight className="ml-2 h-4 w-4" />
               </Button>
             </div>
@@ -464,51 +460,29 @@ function BookingFormContent() {
         {/* Step 2: Date & Time */}
         {currentStep === 2 && (
           <div className="animate-in fade-in slide-in-from-right-4 duration-300">
-            <h2 className="mb-2 text-2xl font-semibold">Select Date & Time</h2>
+            <h2 className="mb-2 text-2xl font-semibold">Select Date & Location</h2>
             <p className="mb-6 text-muted-foreground">
               Choose when and where you&apos;d like your appointment
             </p>
 
-            {/* Date Selection */}
+            {/* Date & Time Selection */}
             <div className="mb-6">
               <Label htmlFor="date" className="mb-2 block text-base font-medium">
-                Preferred Date *
+                Preferred Date & Time *
               </Label>
               <Input
                 id="date"
-                type="date"
+                type="datetime-local"
                 value={bookingDate}
                 onChange={(e) => setBookingDate(e.target.value)}
-                min={new Date().toISOString().split("T")[0]}
+                min={(() => {
+                  const now = new Date();
+                  now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+                  return now.toISOString().slice(0, 16);
+                })()}
                 className="max-w-xs"
                 required
               />
-            </div>
-
-            {/* Time Slot Selection */}
-            <div className="mb-6">
-              <Label className="mb-3 block text-base font-medium">
-                Preferred Time *
-              </Label>
-              <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
-                {TIME_SLOTS.map((slot) => {
-                  const isSelected = bookingTime === slot.value;
-                  return (
-                    <button
-                      key={slot.value}
-                      type="button"
-                      onClick={() => setBookingTime(slot.value)}
-                      className={`rounded-lg border-2 px-3 py-2.5 text-sm font-medium transition-all ${
-                        isSelected
-                          ? "border-secondary bg-secondary text-secondary-foreground"
-                          : "border-border bg-background hover:border-secondary/50 hover:bg-muted"
-                      }`}
-                    >
-                      {slot.label}
-                    </button>
-                  );
-                })}
-              </div>
             </div>
 
             {/* Location Selection */}
@@ -855,7 +829,9 @@ function BookingFormContent() {
                     </div>
                     <div className="flex items-center gap-2">
                       <Clock className="h-4 w-4 text-muted-foreground" />
-                      <span>{formatTime(bookingTime)}</span>
+                      <span>
+                        {formatTime(bookingDate.split("T")[1] || "")}
+                      </span>
                     </div>
                     <div className="flex items-center gap-2">
                       <MapPin className="h-4 w-4 text-muted-foreground" />

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -15,26 +15,16 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { ServicePackage, TransportLocation } from "@/types";
+import { ServicePackage } from "@/types";
 import { getActiveServicePackages, formatPrice, getPricingDescription } from "@/lib/services";
 import {
-  getTransportLocations,
   createBooking,
   calculateBookingPrice,
   formatCurrency,
   formatDate,
   formatTime,
 } from "@/lib/bookings";
-import { calculateTransportCost } from "@/lib/transport-pricing";
 import { LocationAutocomplete } from "@/components/LocationAutocomplete";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -67,21 +57,19 @@ function BookingFormContent() {
 
   // Data state
   const [packages, setPackages] = useState<ServicePackage[]>([]);
-  const [locations, setLocations] = useState<TransportLocation[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Form state
   const [selectedPackageId, setSelectedPackageId] = useState<string>("");
-  const [locationType, setLocationType] = useState<"predefined" | "custom">("predefined");
-  const [selectedLocationId, setSelectedLocationId] = useState<string>("");
   const [customLocation, setCustomLocation] = useState<{
     address: string;
     latitude: number;
     longitude: number;
     distanceKm: number;
   } | null>(null);
+  const [locationDescription, setLocationDescription] = useState<string>("");
   const [bookingDate, setBookingDate] = useState<string>("");
   const [numBrides, setNumBrides] = useState<number>(1);
   const [numMaids, setNumMaids] = useState<number>(0);
@@ -97,19 +85,14 @@ function BookingFormContent() {
 
   // Derived state
   const selectedPackage = packages.find((p) => p.id === selectedPackageId);
-  const selectedLocation = locations.find((l) => l.id === selectedLocationId);
 
   // Load data
   useEffect(() => {
     async function loadData() {
       try {
         setLoading(true);
-        const [packagesData, locationsData] = await Promise.all([
-          getActiveServicePackages(),
-          getTransportLocations(),
-        ]);
+        const packagesData = await getActiveServicePackages();
         setPackages(packagesData);
-        setLocations(locationsData);
 
         // Pre-select package from URL param
         const packageId = searchParams?.get("packageId");
@@ -127,34 +110,24 @@ function BookingFormContent() {
     loadData();
   }, [searchParams]);
 
-  // Calculate price
+  // Calculate price (transport cost is determined manually after booking)
   const pricing =
-    selectedPackage && (selectedLocation || customLocation)
-      ? (() => {
-          const transportCost =
-            locationType === "predefined" && selectedLocation
-              ? parseFloat(selectedLocation.transport_cost)
-              : customLocation
-                ? calculateTransportCost(customLocation.distanceKm).totalCost
-                : 0;
-
-          return calculateBookingPrice(
-            parseFloat(selectedPackage.base_bride_price || "0"),
-            parseFloat(selectedPackage.base_maid_price || "0"),
-            parseFloat(selectedPackage.base_mother_price || "0"),
-            parseFloat(selectedPackage.base_other_price || "0"),
-            numBrides,
-            numMaids,
-            numMothers,
-            numOthers,
-            transportCost
-          );
-        })()
+    selectedPackage && customLocation
+      ? calculateBookingPrice(
+          parseFloat(selectedPackage.base_bride_price || "0"),
+          parseFloat(selectedPackage.base_maid_price || "0"),
+          parseFloat(selectedPackage.base_mother_price || "0"),
+          parseFloat(selectedPackage.base_other_price || "0"),
+          numBrides,
+          numMaids,
+          numMothers,
+          numOthers,
+          0,
+        )
       : null;
 
   // Validation per step
-  const hasValidLocation =
-    locationType === "predefined" ? !!selectedLocationId : !!customLocation;
+  const hasValidLocation = !!customLocation;
 
   const canProceedFromStep = (step: number): boolean => {
     switch (step) {
@@ -239,14 +212,10 @@ function BookingFormContent() {
         package_id: selectedPackageId,
         booking_date: datePart,
         booking_time: submitTime,
-        ...(locationType === "predefined"
-          ? { location_id: selectedLocationId }
-          : {
-              custom_location_address: customLocation!.address,
-              custom_location_latitude: customLocation!.latitude,
-              custom_location_longitude: customLocation!.longitude,
-              custom_location_distance_km: customLocation!.distanceKm,
-            }),
+        custom_location_address: customLocation!.address,
+        custom_location_latitude: customLocation!.latitude,
+        custom_location_longitude: customLocation!.longitude,
+        location_description: locationDescription || undefined,
         num_brides: numBrides,
         num_maids: numMaids,
         num_mothers: numMothers,
@@ -486,54 +455,12 @@ function BookingFormContent() {
             </div>
 
             {/* Location Selection */}
-            <div className="mb-6">
-              <Label className="mb-3 block text-base font-medium">
-                Location *
-              </Label>
-
-              <RadioGroup
-                value={locationType}
-                onValueChange={(value) =>
-                  setLocationType(value as "predefined" | "custom")
-                }
-                className="mb-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="predefined" id="predefined" />
-                  <Label htmlFor="predefined" className="cursor-pointer font-normal">
-                    Choose from predefined locations (Nairobi/Kitui)
-                  </Label>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="custom" id="custom" />
-                  <Label htmlFor="custom" className="cursor-pointer font-normal">
-                    Search for my location
-                  </Label>
-                </div>
-              </RadioGroup>
-
-              {locationType === "predefined" ? (
+            <div className="mb-6 space-y-4">
+              <div>
+                <Label className="mb-2 block text-base font-medium">
+                  Location *
+                </Label>
                 <div className="max-w-md">
-                  <Select
-                    value={selectedLocationId}
-                    onValueChange={setSelectedLocationId}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select location" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {locations.map((loc) => (
-                        <SelectItem key={loc.id} value={loc.id}>
-                          {loc.location_name}
-                          {parseFloat(loc.transport_cost) > 0 &&
-                            ` (+${formatCurrency(parseFloat(loc.transport_cost))})`}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ) : (
-                <div className="max-w-md space-y-2">
                   <LocationAutocomplete
                     onLocationSelect={(location) => {
                       setCustomLocation({
@@ -546,19 +473,32 @@ function BookingFormContent() {
                     placeholder="Search for your location in Kenya..."
                   />
                   {customLocation && (
-                    <div className="rounded-md border border-border bg-muted/50 p-3">
+                    <div className="mt-2 rounded-md border border-border bg-muted/50 p-3">
                       <p className="text-sm font-medium">{customLocation.address}</p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Distance from Nairobi: {customLocation.distanceKm.toFixed(1)}{" "}
-                        km {" · "} Transport cost:{" "}
-                        {formatCurrency(
-                          calculateTransportCost(customLocation.distanceKm).totalCost
-                        )}
-                      </p>
                     </div>
                   )}
                 </div>
-              )}
+              </div>
+
+              <div className="max-w-md">
+                <Label
+                  htmlFor="location-description"
+                  className="mb-2 block text-base font-medium"
+                >
+                  Location details
+                </Label>
+                <Textarea
+                  id="location-description"
+                  value={locationDescription}
+                  onChange={(e) => setLocationDescription(e.target.value)}
+                  placeholder="Apartment, floor, landmarks, gate code, or directions to help us find the exact spot"
+                  rows={3}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Transport cost will be confirmed by our team after we verify
+                  availability and location.
+                </p>
+              </div>
             </div>
 
             {/* Navigation */}
@@ -833,13 +773,16 @@ function BookingFormContent() {
                         {formatTime(bookingDate.split("T")[1] || "")}
                       </span>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <MapPin className="h-4 w-4 text-muted-foreground" />
-                      <span>
-                        {locationType === "predefined"
-                          ? selectedLocation?.location_name || "—"
-                          : customLocation?.address || "—"}
-                      </span>
+                    <div className="flex items-start gap-2">
+                      <MapPin className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                      <div>
+                        <p>{customLocation?.address || "—"}</p>
+                        {locationDescription && (
+                          <p className="text-xs text-muted-foreground whitespace-pre-line">
+                            {locationDescription}
+                          </p>
+                        )}
+                      </div>
                     </div>
                   </div>
                 </CardContent>

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -264,8 +264,12 @@ function BookingFormContent() {
       const token = (session as any)?.accessToken;
       const booking = await createBooking(bookingData, token);
 
+      // Keep the cached payload as a fast-path; the signed token in the
+      // URL is the durable way to re-open the page on refresh / new tab.
       sessionStorage.setItem(`booking_${booking.id}`, JSON.stringify(booking));
-      router.push(`/bookings/${booking.id}/confirmation`);
+      router.push(
+        `/bookings/${booking.id}/confirmation?token=${encodeURIComponent(booking.confirmationToken)}`,
+      );
     } catch (err: any) {
       console.error("Failed to create booking:", err);
       setError(err.message || "Failed to create booking. Please try again.");
@@ -981,24 +985,40 @@ function BookingFormContent() {
                         <span className="text-muted-foreground">
                           Transport:
                         </span>
-                        <span>{formatCurrency(pricing.transport)}</span>
+                        <span className="italic text-muted-foreground">
+                          To be confirmed
+                        </span>
                       </div>
                       <div className="border-t border-border pt-3">
                         <div className="flex justify-between text-lg font-semibold">
-                          <span>Total:</span>
+                          <span>Service Total:</span>
                           <span>{formatCurrency(pricing.total)}</span>
                         </div>
                         <div className="mt-2 flex justify-between text-sm">
                           <span className="text-muted-foreground">
-                            Deposit Required (50%):
+                            Deposit (50% of service total):
                           </span>
                           <span className="font-semibold text-secondary">
                             {formatCurrency(pricing.deposit)}
                           </span>
                         </div>
-                        <p className="mt-2 text-xs text-muted-foreground">
-                          Remaining {formatCurrency(pricing.total - pricing.deposit)} due after service delivery
-                        </p>
+                      </div>
+                      <div className="mt-4 rounded-md border border-secondary/40 bg-secondary/10 p-3 text-sm text-secondary">
+                        <p className="font-semibold">How payment works</p>
+                        <ul className="mt-1 list-disc space-y-1 pl-5 text-secondary/90">
+                          <li>
+                            Transport cost will be communicated after we
+                            verify availability and your location.
+                          </li>
+                          <li>
+                            The 50% deposit is paid once that transport
+                            quote is confirmed with you.
+                          </li>
+                          <li>
+                            The remaining 50% is paid on the service
+                            delivery day, before the service is provided.
+                          </li>
+                        </ul>
                       </div>
                     </div>
                   </CardContent>
@@ -1012,12 +1032,13 @@ function BookingFormContent() {
                 <ChevronLeft className="mr-2 h-4 w-4" />
                 Back
               </Button>
-              <div className="flex flex-col gap-3 sm:flex-row">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
                 {selectedPackage && (
                   <WhatsAppButton
                     variant="outline"
                     size="lg"
                     label="Book on WhatsApp"
+                    className="sm:flex-1"
                     context={{
                       type: "service",
                       service_id: selectedPackage.id,
@@ -1029,6 +1050,7 @@ function BookingFormContent() {
                   onClick={handleSubmit}
                   disabled={!canSubmit || attendeeErrors.length > 0 || submitting}
                   size="lg"
+                  className="w-full sm:w-auto sm:flex-1"
                 >
                   {submitting ? (
                     <>

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -1,6 +1,6 @@
 /**
  * New Booking Page - Tab-based Multi-step Wizard
- * 4-step booking flow: Choose Service → Date & Time → Your Details → Review & Confirm
+ * 5-step booking flow: Choose Service → Date & Location → Event Details → Contact Information → Review & Confirm
  */
 
 "use client";
@@ -38,13 +38,15 @@ import {
   ChevronLeft,
   Sparkles,
   ClipboardCheck,
+  ContactRound,
 } from "lucide-react";
 
 const STEPS = [
   { id: 1, label: "Choose Service", icon: Sparkles },
   { id: 2, label: "Date & Location", icon: Calendar },
-  { id: 3, label: "Your Details", icon: Users },
-  { id: 4, label: "Review & Confirm", icon: ClipboardCheck },
+  { id: 3, label: "Event Details", icon: Users },
+  { id: 4, label: "Contact Information", icon: ContactRound },
+  { id: 5, label: "Review & Confirm", icon: ClipboardCheck },
 ] as const;
 
 function BookingFormContent() {
@@ -60,6 +62,18 @@ function BookingFormContent() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // --- Contact validation -------------------------------------------------
+  // Loose enough to accept anything that's recognisably an email — a
+  // single @ with a TLD-looking right-hand side. We're after "is this
+  // address typo-free enough to reach the user", not RFC compliance.
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+  // Kenyan mobile: +254 7XX/1XX XXX XXX, or 07XX/01XX XXX XXX. Strip
+  // spaces/dashes before checking.
+  const PHONE_RE = /^(?:\+?254|0)(?:7|1)\d{8}$/;
+  const normalizePhone = (s: string) => s.replace(/[\s-]/g, "");
+  const isValidEmail = (s: string) => EMAIL_RE.test(s.trim());
+  const isValidPhone = (s: string) => PHONE_RE.test(normalizePhone(s));
 
   // Form state
   const [selectedPackageId, setSelectedPackageId] = useState<string>("");
@@ -110,6 +124,15 @@ function BookingFormContent() {
     loadData();
   }, [searchParams]);
 
+  // When the selected package changes, snap numMaids into the package's
+  // [min_maids, max_maids] range so the form starts at a valid state.
+  useEffect(() => {
+    if (!selectedPackage) return;
+    const min = selectedPackage.min_maids ?? 0;
+    const max = selectedPackage.max_maids ?? Infinity;
+    setNumMaids((current) => Math.min(Math.max(current, min), max));
+  }, [selectedPackage]);
+
   // Calculate price (transport cost is determined manually after booking)
   const pricing =
     selectedPackage && customLocation
@@ -136,8 +159,14 @@ function BookingFormContent() {
       case 2:
         return !!bookingDate && hasValidLocation;
       case 3:
-        return user ? true : !!(guestName && guestEmail && guestPhone);
+        return attendeeErrors.length === 0;
       case 4:
+        return user
+          ? true
+          : !!guestName.trim() &&
+              isValidEmail(guestEmail) &&
+              isValidPhone(guestPhone);
+      case 5:
         return true;
       default:
         return false;
@@ -148,7 +177,10 @@ function BookingFormContent() {
     selectedPackageId &&
     hasValidLocation &&
     bookingDate &&
-    (user || (guestName && guestEmail && guestPhone)) &&
+    (user ||
+      (guestName.trim() &&
+        isValidEmail(guestEmail) &&
+        isValidPhone(guestPhone))) &&
     pricing &&
     pricing.total > 0;
 
@@ -177,7 +209,7 @@ function BookingFormContent() {
   };
 
   const nextStep = () => {
-    if (canProceedFromStep(currentStep) && currentStep < 4) {
+    if (canProceedFromStep(currentStep) && currentStep < 5) {
       setCurrentStep(currentStep + 1);
       setError(null);
       window.scrollTo({ top: 0, behavior: "smooth" });
@@ -223,9 +255,9 @@ function BookingFormContent() {
         wedding_theme: weddingTheme || undefined,
         special_requests: specialRequests || undefined,
         ...(!user && {
-          guest_name: guestName,
-          guest_email: guestEmail,
-          guest_phone: guestPhone,
+          guest_name: guestName.trim(),
+          guest_email: guestEmail.trim(),
+          guest_phone: normalizePhone(guestPhone),
         }),
       };
 
@@ -513,17 +545,17 @@ function BookingFormContent() {
                 disabled={!canProceedFromStep(2)}
                 size="lg"
               >
-                Continue to Details
+                Continue to Event Details
                 <ChevronRight className="ml-2 h-4 w-4" />
               </Button>
             </div>
           </div>
         )}
 
-        {/* Step 3: Your Details */}
+        {/* Step 3: Event Details */}
         {currentStep === 3 && (
           <div className="animate-in fade-in slide-in-from-right-4 duration-300">
-            <h2 className="mb-2 text-2xl font-semibold">Your Details</h2>
+            <h2 className="mb-2 text-2xl font-semibold">Event Details</h2>
             <p className="mb-6 text-muted-foreground">
               Tell us about your event and how many people need makeup
             </p>
@@ -567,15 +599,25 @@ function BookingFormContent() {
                       <div className="space-y-2">
                         <Label htmlFor="maids">
                           Maids/Bridesmaids ({formatCurrency(parseFloat(selectedPackage.base_maid_price))} each)
+                          {selectedPackage.min_maids ? (
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              · minimum {selectedPackage.min_maids}
+                            </span>
+                          ) : null}
                         </Label>
                         <Input
                           id="maids"
                           type="number"
-                          min="0"
-                          value={numMaids || ""}
-                          onChange={(e) =>
-                            setNumMaids(parseInt(e.target.value) || 0)
-                          }
+                          min={selectedPackage.min_maids ?? 0}
+                          max={selectedPackage.max_maids ?? undefined}
+                          value={numMaids}
+                          onChange={(e) => {
+                            const raw = parseInt(e.target.value);
+                            const min = selectedPackage.min_maids ?? 0;
+                            const max = selectedPackage.max_maids ?? Infinity;
+                            const next = Number.isNaN(raw) ? min : raw;
+                            setNumMaids(Math.min(Math.max(next, min), max));
+                          }}
                         />
                       </div>
                     )}
@@ -648,48 +690,94 @@ function BookingFormContent() {
               </div>
             </div>
 
-            {/* Guest Information (if not logged in) */}
-            {!user && (
-              <div className="mb-6">
-                <h3 className="mb-3 text-lg font-medium">
-                  Contact Information
-                </h3>
-                <p className="mb-4 text-sm text-muted-foreground">
-                  We&apos;ll use this to confirm your booking
-                </p>
-                <div className="space-y-4">
+            {/* Navigation */}
+            <div className="mt-8 flex justify-between">
+              <Button variant="outline" onClick={prevStep} size="lg">
+                <ChevronLeft className="mr-2 h-4 w-4" />
+                Back
+              </Button>
+              <Button
+                onClick={nextStep}
+                disabled={!canProceedFromStep(3)}
+                size="lg"
+              >
+                Continue to Contact Info
+                <ChevronRight className="ml-2 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 4: Contact Information */}
+        {currentStep === 4 && (
+          <div className="animate-in fade-in slide-in-from-right-4 duration-300">
+            <h2 className="mb-2 text-2xl font-semibold">Contact Information</h2>
+            <p className="mb-6 text-muted-foreground">
+              We&apos;ll use this to confirm your booking and share any
+              additional details about your appointment.
+            </p>
+
+            {user ? (
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Signed in as</p>
+                  <p className="font-medium">{user.email}</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="guestName">Full Name *</Label>
+                  <Input
+                    id="guestName"
+                    type="text"
+                    value={guestName}
+                    onChange={(e) => setGuestName(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="guestName">Full Name *</Label>
+                    <Label htmlFor="guestEmail">Email Address *</Label>
                     <Input
-                      id="guestName"
-                      type="text"
-                      value={guestName}
-                      onChange={(e) => setGuestName(e.target.value)}
+                      id="guestEmail"
+                      type="email"
+                      value={guestEmail}
+                      onChange={(e) => setGuestEmail(e.target.value)}
+                      aria-invalid={
+                        guestEmail.length > 0 && !isValidEmail(guestEmail)
+                      }
                       required
                     />
+                    {guestEmail.length > 0 && !isValidEmail(guestEmail) && (
+                      <p className="text-xs text-destructive">
+                        Enter a valid email address (e.g. you@example.com).
+                      </p>
+                    )}
                   </div>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="guestEmail">Email Address *</Label>
-                      <Input
-                        id="guestEmail"
-                        type="email"
-                        value={guestEmail}
-                        onChange={(e) => setGuestEmail(e.target.value)}
-                        required
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="guestPhone">Phone Number *</Label>
-                      <Input
-                        id="guestPhone"
-                        type="tel"
-                        placeholder="+254 7XX XXX XXX"
-                        value={guestPhone}
-                        onChange={(e) => setGuestPhone(e.target.value)}
-                        required
-                      />
-                    </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="guestPhone">Phone Number *</Label>
+                    <Input
+                      id="guestPhone"
+                      type="tel"
+                      placeholder="+254 7XX XXX XXX"
+                      value={guestPhone}
+                      onChange={(e) => setGuestPhone(e.target.value)}
+                      aria-invalid={
+                        guestPhone.length > 0 && !isValidPhone(guestPhone)
+                      }
+                      required
+                    />
+                    {guestPhone.length > 0 && !isValidPhone(guestPhone) ? (
+                      <p className="text-xs text-destructive">
+                        Enter a Kenyan mobile number, e.g. +254 712 345 678 or
+                        0712 345 678.
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        Kenyan mobile: +254 7XX XXX XXX or 07XX XXX XXX.
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>
@@ -703,7 +791,7 @@ function BookingFormContent() {
               </Button>
               <Button
                 onClick={nextStep}
-                disabled={!canProceedFromStep(3)}
+                disabled={!canProceedFromStep(4)}
                 size="lg"
               >
                 Review Booking
@@ -713,8 +801,8 @@ function BookingFormContent() {
           </div>
         )}
 
-        {/* Step 4: Review & Confirm */}
-        {currentStep === 4 && (
+        {/* Step 5: Review & Confirm */}
+        {currentStep === 5 && (
           <div className="animate-in fade-in slide-in-from-right-4 duration-300">
             <h2 className="mb-2 text-2xl font-semibold">Review & Confirm</h2>
             <p className="mb-6 text-muted-foreground">
@@ -854,7 +942,7 @@ function BookingFormContent() {
                       </h3>
                       <button
                         type="button"
-                        onClick={() => goToStep(3)}
+                        onClick={() => goToStep(4)}
                         className="text-sm text-secondary hover:underline"
                       >
                         Edit

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -494,7 +494,8 @@ function BookingFormContent() {
                   placeholder="Apartment, floor, landmarks, gate code, or directions to help us find the exact spot"
                   rows={3}
                 />
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="mt-2 text-sm font-semibold text-secondary">
+                  Some areas within Kitui town and Nairobi town are free.
                   Transport cost will be confirmed by our team after we verify
                   availability and location.
                 </p>

--- a/frontend/src/components/WhatsAppButton.tsx
+++ b/frontend/src/components/WhatsAppButton.tsx
@@ -11,6 +11,7 @@ export type WhatsAppContext =
   | { type: "product"; product_id: string; quantity?: number }
   | { type: "service"; service_id: string; preferred_date?: string }
   | { type: "cart"; items: Array<{ product_id: string; quantity: number }> }
+  | { type: "booking"; booking_number: string }
   | { type: "general" };
 
 type Variant = "outline" | "icon";
@@ -95,10 +96,10 @@ export function WhatsAppButton({
 
   const sizeClasses =
     size === "sm"
-      ? "py-2 text-sm"
+      ? "py-2 px-4 text-sm"
       : size === "lg"
-        ? "py-3.5 text-base"
-        : "py-3 text-sm";
+        ? "py-3.5 px-8 text-base"
+        : "py-3 px-4 text-sm";
 
   return (
     <button

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -41,6 +41,7 @@ export const API_ENDPOINTS = {
     CREATE: "/api/bookings",
     LIST: "/api/bookings",
     DETAIL: (id: string) => `/api/bookings/${id}`,
+    CONFIRMATION: (id: string) => `/api/bookings/${id}/confirmation`,
     AVAILABILITY: "/api/bookings/availability",
     CANCEL: (id: string) => `/api/bookings/${id}/cancel`,
   },

--- a/frontend/src/lib/bookings.ts
+++ b/frontend/src/lib/bookings.ts
@@ -85,7 +85,7 @@ export async function createBooking(
     guest_phone?: string;
   },
   token?: string
-): Promise<Booking> {
+): Promise<Booking & { confirmationToken: string }> {
   const headers: HeadersInit = {
     "Content-Type": "application/json",
   };
@@ -106,7 +106,29 @@ export async function createBooking(
   }
 
   const data = await response.json();
-  return transformBookingResponse(data);
+  return {
+    ...transformBookingResponse(data),
+    confirmationToken: data.confirmation_token,
+  };
+}
+
+/**
+ * Look up a booking via the signed confirmation token returned at
+ * creation time. Public — no auth required.
+ */
+export async function getBookingConfirmation(
+  bookingId: string,
+  confirmationToken: string,
+): Promise<Booking> {
+  const url = `${API_BASE_URL}${API_ENDPOINTS.BOOKINGS.CONFIRMATION(bookingId)}?token=${encodeURIComponent(confirmationToken)}`;
+  const response = await fetch(url, { method: "GET", cache: "no-store" });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      errorData.detail || `Failed to fetch confirmation: ${response.statusText}`,
+    );
+  }
+  return transformBookingResponse(await response.json());
 }
 
 /**


### PR DESCRIPTION
## Summary

Rebuilds the booking wizard around a guest-first, seamless flow and replaces the brittle confirmation page with a signed, shareable URL.

### Booking wizard (`/bookings/new`)

- 5 steps: **Choose Service → Date & Location → Event Details → Contact Information → Review & Confirm**.
- **Step 2** uses a single `datetime-local` for the desired moment (the old constrained time-slot grid is gone) and a single `LocationAutocomplete` search + an extra "Location details" textarea for landmarks / directions. The brand-pink note clarifies that **some areas within Kitui town and Nairobi town are free** and transport is confirmed manually.
- **Step 3** ("Event Details") pre-seeds and clamps `numMaids` into `[min_maids, max_maids]` for the chosen package so the form starts at a valid state.
- **Step 4** ("Contact Information") validates email (regex) and phone (Kenyan mobile: `+254 / 254 / 0` prefix, 7XX/1XX, 8 digits) with inline destructive hints; submit is gated on both passing. Phone is normalised before submission.
- **Step 5** Price Summary now reads `Service subtotal / Transport: To be confirmed / Service Total / Deposit (50% of service total)` plus a pink **"How payment works"** callout. The **Book on WhatsApp** and **Confirm Booking** buttons sit on the same row at the same size (`sm:flex-1`, `lg` size).

### Backend

- New Alembic migration `e5f6a7b8c9d0` adds `bookings.location_description TEXT NULL` and relaxes the location check constraint to `location_id IS NOT NULL OR custom_location_address IS NOT NULL`.
- `BookingCreate` requires only `custom_location_address`; lat/lng/distance are optional. `calculate_booking_price` no longer takes a location and always returns `transport_cost = 0`. The update path preserves any transport cost the admin sets later.
- `POST /api/bookings` now returns a `confirmation_token` (JWT, 30-day TTL, `type=booking_confirmation`, signed with `SECRET_KEY`). New public `GET /api/bookings/{id}/confirmation?token=...` validates the token-binds-to-id pair and returns the booking — solves the previous bug where guests couldn't refresh or share the confirmation URL.
- WhatsApp endpoint extended with a `{type:"booking", booking_number}` context. The link redirect now points to `/services/{id}` for `service` contexts (previously a deep link into the booking wizard).

### Confirmation page (`/bookings/[id]/confirmation`)

- Loads via the URL token first; sessionStorage cache and authenticated owner fetch are fallbacks.
- "What happens next" surfaced directly under the booking number (pink callout) so the customer doesn't have to scroll to learn the team will call/WhatsApp them to confirm availability, location, final cost, and deposit instructions.
- New **"Reach us on WhatsApp"** CTA renders `wa.me` with a prefilled message including the booking number.
- Price Summary now matches the Review step (subtotal / "transport to be confirmed" / service total / deposit + payment-policy callout).
- The placeholder Payment Instructions card is removed — payment details are shared over WhatsApp after the cost is finalised.

### Featured-service cards

Homepage and `/services` cards are clickable (mouse + keyboard) → `/services/{id}`, with a consistent CTA hierarchy: solid pink **Book Now** + pink-outline **View Details** side by side, full-width **Book on WhatsApp** below.

## Test plan

- [ ] Step 2 datetime-local accepts any future date+time; no time-slot grid is shown.
- [ ] Location search submits with address + free-text description; no predefined-locations dropdown is visible.
- [ ] Step 3 prevents reducing maids below `min_maids` for the package; "minimum N" hint is shown.
- [ ] Step 4 shows inline error for malformed email and rejects non-Kenyan phone formats; phone is stripped of spaces/dashes on submit.
- [ ] Step 5 Review summary lists location address with the description; price summary shows "Transport: To be confirmed" and the pink payment callout.
- [ ] After submit, the URL is `/bookings/<id>/confirmation?token=...`; refresh works for guests; opening in a new tab works.
- [ ] On the confirmation page, "Reach us on WhatsApp" opens `wa.me/<phone>?text=...` with the booking number in the prefilled message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)