### PR TITLE
feat(bookings): friendlier date picker, persistent WhatsApp, booking emails & required phone

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,12 +36,25 @@ AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 AWS_REGION=us-east-1
 S3_BUCKET_NAME=glam-by-lynn-uploads
 
-# Email (Resend)
+# Email
+# Provider: console (dev — prints to logs), resend, or sendgrid.
+# Note: "smtp" is not implemented. Leave as console to disable real sending.
+EMAIL_PROVIDER=console
+# Sender identity (EMAIL_FROM must be a verified domain/sender with your provider).
+EMAIL_FROM=noreply@glambylynn.com
+EMAIL_FROM_NAME=Glam by Lynn
+# Required when EMAIL_PROVIDER=resend
 RESEND_API_KEY=your-resend-api-key
-FROM_EMAIL=noreply@glambylynn.com
+# Required only when EMAIL_PROVIDER=sendgrid
+# SENDGRID_API_KEY=your-sendgrid-api-key
 
 # Admin
+# Recipients of internal notifications (e.g. "new booking to review").
+# Comma-separated; if empty, no admin emails are sent.
 ADMIN_EMAILS=admin@glambylynn.com,lynn@glambylynn.com
+
+# WhatsApp / business phone for booking follow-up + call buttons is NOT an
+# env var — set it in the app under Admin → Settings (key: whatsapp_phone_number).
 
 # Rate Limiting
 RATE_LIMIT_PER_MINUTE=60

--- a/backend/EMAIL_SETUP.md
+++ b/backend/EMAIL_SETUP.md
@@ -9,13 +9,34 @@ Add the following environment variables to your `.env` file:
 ### Basic Configuration
 
 ```env
-# Email Provider (console, resend, sendgrid, smtp)
+# Email Provider: console (dev), resend, or sendgrid
+# Note: "smtp" is NOT implemented — only console, resend, and sendgrid work.
 EMAIL_PROVIDER=console
 
-# From Email Address
+# Sender identity. EMAIL_FROM must be a verified domain/sender with your provider.
 EMAIL_FROM=noreply@glambylynn.com
 EMAIL_FROM_NAME=Glam by Lynn
 ```
+
+> ⚠️ The email service reads `EMAIL_FROM` (not `FROM_EMAIL`). The `FROM_EMAIL`
+> setting in `app/core/config.py` is unrelated to outbound mail.
+
+### Recipients & links (booking notifications)
+
+```env
+# Comma-separated recipients of internal notifications (e.g. "new booking to
+# review"). If empty, no admin emails are sent (the customer email still goes out).
+ADMIN_EMAILS=admin@glambylynn.com,lynn@glambylynn.com
+
+# Used to build links in emails (e.g. the admin "Open in dashboard" button).
+FRONTEND_URL=https://glambylynn.com
+```
+
+The customer "Follow up on WhatsApp" / "Call us" buttons and the admin
+"WhatsApp customer" button use the business number stored under the
+`whatsapp_phone_number` site setting — configured in the app under
+**Admin → Settings**, not via env. If it's unset, those buttons are omitted
+and the email still sends.
 
 ### Provider-Specific Configuration
 
@@ -29,21 +50,23 @@ EMAIL_PROVIDER=console
 
 #### Option 2: Resend (Recommended for Production)
 
+The `resend` package is included in `requirements.txt`, so no extra install is needed.
+
 1. Sign up at [resend.com](https://resend.com)
-2. Create an API key
-3. Install the package: `pip install resend`
-4. Configure:
+2. Verify your sending domain and create an API key
+3. Configure:
 
 ```env
 EMAIL_PROVIDER=resend
 RESEND_API_KEY=your_resend_api_key_here
+EMAIL_FROM=bookings@glambylynn.com   # must be on the verified domain
 ```
 
 #### Option 3: SendGrid
 
 1. Sign up at [sendgrid.com](https://sendgrid.com)
 2. Create an API key
-3. Install the package: `pip install sendgrid`
+3. Install the package: `pip install sendgrid` (not bundled in requirements.txt)
 4. Configure:
 
 ```env
@@ -60,10 +83,16 @@ The service includes responsive HTML templates for:
 - Includes order details, items, totals, delivery address
 - Brand colors: Black background with pink accents
 
-### 2. Booking Confirmation Email
-- Sent when customer books a service
-- Includes booking reference, service details, date/time, location
-- Reminder to arrive 10 minutes early
+### 2. Booking Notification Emails
+Sent automatically when a booking is created (via FastAPI background tasks, so
+a slow/failing provider never blocks or fails the booking):
+- **Customer** (`send_booking_received_customer`) — confirms the request was
+  received (pending, not yet confirmed), summarises the details, explains what
+  happens next, and offers "Follow up on WhatsApp" + "Call us" buttons.
+- **Team** (`send_booking_admin_notification`) — sent to each `ADMIN_EMAILS`
+  address with the customer's contact, full booking details, an action
+  checklist, and "Call customer" / "WhatsApp customer" / "Open in dashboard"
+  buttons.
 
 ### 3. Vision Registration Confirmation Email
 - Sent when someone registers interest in 2026 expansion
@@ -90,16 +119,20 @@ email_service.send_order_confirmation(
     delivery_address={...},
 )
 
-# Send booking confirmation
-email_service.send_booking_confirmation(
+# Booking notifications are sent automatically on booking creation — see
+# app/services/booking_notifications.py (scheduled from the create-booking
+# route via BackgroundTasks). To send one directly:
+email_service.send_booking_received_customer(
     to_email="customer@example.com",
-    booking_reference="BKG-12345",
+    booking_number="BK202601150001",
     customer_name="Jane Doe",
     service_name="Bridal Makeup Package",
-    booking_date=datetime(2026, 1, 15),
-    booking_time="10:00 AM",
-    location="Nairobi Studio",
-    total_price=Decimal("5000.00"),
+    booking_date=date(2026, 1, 15),
+    location="Karen, Nairobi",
+    subtotal=Decimal("5000.00"),
+    deposit=Decimal("2500.00"),
+    whatsapp_url="https://wa.me/2547...",   # optional
+    call_number="2547...",                  # optional
 )
 
 # Send vision registration confirmation

--- a/backend/app/routers/bookings.py
+++ b/backend/app/routers/bookings.py
@@ -2,7 +2,7 @@
 Public Booking API routes
 Publicly accessible endpoints for booking availability and creation
 """
-from fastapi import APIRouter, Depends, Query, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, HTTPException, status
 from sqlalchemy.orm import Session
 from datetime import date as date_type, timedelta
 from typing import Optional
@@ -24,6 +24,7 @@ from app.schemas.booking import (
     BookingListResponse,
 )
 from app.services import booking_service
+from app.services.booking_notifications import schedule_booking_notifications
 import math
 
 router = APIRouter(prefix="/bookings", tags=["bookings"])
@@ -212,6 +213,7 @@ async def get_booking_details(
 @router.post("", response_model=BookingCreateResponse, status_code=status.HTTP_201_CREATED)
 async def create_booking(
     booking_data: BookingCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: Optional[User] = Depends(get_optional_current_user)
 ):
@@ -261,6 +263,12 @@ async def create_booking(
         )
 
         token = create_booking_confirmation_token(booking.id)
+
+        # Notify the customer (with follow-up options) and the team (to review
+        # and reach out). Runs after the response is sent; never blocks or
+        # fails the booking itself.
+        schedule_booking_notifications(db, booking, background_tasks)
+
         return {
             **BookingResponse.model_validate(booking).model_dump(),
             "confirmation_token": token,

--- a/backend/app/services/booking_notifications.py
+++ b/backend/app/services/booking_notifications.py
@@ -1,0 +1,175 @@
+"""Booking notification orchestration.
+
+Gathers everything the customer- and admin-facing emails need while the
+request's DB session is still open, then schedules the actual sends on
+FastAPI background tasks so a slow or failing mail provider never blocks
+(or fails) the booking itself.
+"""
+import json
+import re
+from decimal import Decimal
+from typing import List, Optional
+from urllib.parse import quote
+
+from fastapi import BackgroundTasks
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.booking import Booking
+from app.services import site_settings_service
+from app.services.email_service import email_service
+
+PHONE_KEY = "whatsapp_phone_number"
+
+
+def _resolve_business_phone(db: Session) -> Optional[str]:
+    """Return the configured WhatsApp/business number as digits, or None."""
+    raw = site_settings_service.get_setting(db, PHONE_KEY)
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        value = raw
+    digits = re.sub(r"\D", "", str(value))
+    return digits if 8 <= len(digits) <= 15 else None
+
+
+def _booking_followup_url(phone: str, booking_number: str) -> str:
+    """wa.me link a customer can use to follow up on their booking."""
+    message = (
+        "Hi Glam by Lynn — I'd like to follow up on my booking.\n"
+        f"Booking number: {booking_number}"
+    )
+    return f"https://wa.me/{phone}?text={quote(message)}"
+
+
+def _normalize_ke_phone(phone: str) -> Optional[str]:
+    """Normalise a Kenyan phone number to wa.me digits (2547XXXXXXXX).
+
+    Accepts 07XXXXXXXX / 01XXXXXXXX, +2547XXXXXXXX, or 2547XXXXXXXX.
+    Returns None if it doesn't look like a usable number.
+    """
+    digits = re.sub(r"\D", "", phone or "")
+    if digits.startswith("0") and len(digits) == 10:
+        digits = "254" + digits[1:]
+    elif digits.startswith("254") and len(digits) == 12:
+        pass
+    elif digits.startswith("7") or digits.startswith("1"):
+        if len(digits) == 9:
+            digits = "254" + digits
+    return digits if 11 <= len(digits) <= 15 else None
+
+
+def _customer_contact_url(customer_phone: str, customer_name: str, booking_number: str) -> Optional[str]:
+    """wa.me link the team can use to message the customer about a booking.
+
+    Points at the *customer's* number so the chat opens with them.
+    """
+    normalized = _normalize_ke_phone(customer_phone)
+    if not normalized:
+        return None
+    message = (
+        f"Hi {customer_name}, this is Glam by Lynn regarding your booking "
+        f"{booking_number}."
+    )
+    return f"https://wa.me/{normalized}?text={quote(message)}"
+
+
+def _format_attendees(booking: Booking) -> str:
+    parts = []
+    pairs = [
+        (booking.num_brides, "bride", "brides"),
+        (booking.num_maids, "maid", "maids"),
+        (booking.num_mothers, "mother", "mothers"),
+        (booking.num_others, "other", "others"),
+    ]
+    for count, singular, plural in pairs:
+        if count and count > 0:
+            parts.append(f"{count} {singular if count == 1 else plural}")
+    return ", ".join(parts) if parts else "Not specified"
+
+
+def _location_text(booking: Booking) -> str:
+    if booking.custom_location_address:
+        return booking.custom_location_address
+    if booking.location and getattr(booking.location, "location_name", None):
+        return booking.location.location_name
+    return "To be confirmed"
+
+
+def schedule_booking_notifications(
+    db: Session,
+    booking: Booking,
+    background_tasks: BackgroundTasks,
+) -> None:
+    """Queue customer + admin emails for a freshly created booking.
+
+    Resolves all data up front (relationships, settings) so the background
+    tasks receive plain values and don't touch the request-scoped session.
+    """
+    # Customer contact — guest fields take precedence, fall back to the
+    # registered user's profile.
+    customer_email = booking.guest_email or (booking.user.email if booking.user else None)
+    customer_name = (
+        booking.guest_name
+        or (booking.user.full_name if booking.user else None)
+        or "there"
+    )
+    customer_phone = booking.guest_phone or (
+        booking.user.phone_number if booking.user else None
+    ) or ""
+
+    service_name = booking.package.name if booking.package else "Makeup service"
+    location = _location_text(booking)
+    attendees = _format_attendees(booking)
+    subtotal = Decimal(booking.subtotal or 0)
+    deposit = Decimal(booking.deposit_amount or 0)
+
+    phone = _resolve_business_phone(db)
+    followup_url = (
+        _booking_followup_url(phone, booking.booking_number) if phone else None
+    )
+    customer_wa_url = (
+        _customer_contact_url(customer_phone, customer_name, booking.booking_number)
+        if customer_phone
+        else None
+    )
+    admin_url = f"{settings.FRONTEND_URL.rstrip('/')}/admin/bookings"
+
+    # Customer notification
+    if customer_email:
+        background_tasks.add_task(
+            email_service.send_booking_received_customer,
+            to_email=customer_email,
+            booking_number=booking.booking_number,
+            customer_name=customer_name,
+            service_name=service_name,
+            booking_date=booking.booking_date,
+            location=location,
+            subtotal=subtotal,
+            deposit=deposit,
+            whatsapp_url=followup_url,
+            call_number=phone,
+        )
+
+    # Admin notification(s)
+    admin_recipients: List[str] = list(settings.ADMIN_EMAILS or [])
+    for admin_email in admin_recipients:
+        background_tasks.add_task(
+            email_service.send_booking_admin_notification,
+            to_email=admin_email,
+            booking_number=booking.booking_number,
+            customer_name=customer_name,
+            customer_email=customer_email or "Not provided",
+            customer_phone=customer_phone or "Not provided",
+            service_name=service_name,
+            booking_date=booking.booking_date,
+            location=location,
+            location_description=booking.location_description,
+            attendees=attendees,
+            subtotal=subtotal,
+            special_requests=booking.special_requests,
+            admin_url=admin_url,
+            customer_whatsapp_url=customer_wa_url,
+        )

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,5 +1,6 @@
 """Email service for sending transactional emails."""
 import os
+import re
 from typing import Optional, Dict, Any
 from datetime import datetime
 from decimal import Decimal
@@ -280,34 +281,65 @@ class EmailService:
 
         return self.send_email(to_email, subject, html_content, text_content)
 
-    def send_booking_confirmation(
+    def send_booking_received_customer(
         self,
         to_email: str,
-        booking_reference: str,
+        booking_number: str,
         customer_name: str,
         service_name: str,
         booking_date: datetime,
-        booking_time: str,
         location: str,
-        total_price: Decimal,
+        subtotal: Decimal,
+        deposit: Decimal,
+        whatsapp_url: Optional[str] = None,
+        call_number: Optional[str] = None,
     ) -> bool:
         """
-        Send booking confirmation email.
+        Notify the customer that we've received their booking request.
+
+        The booking is not yet confirmed — our team reviews it, verifies
+        availability and location, and gets back in touch with the transport
+        quote and payment instructions. The email gives the customer a clear
+        way to follow up (WhatsApp / call) instead of waiting passively.
 
         Args:
             to_email: Customer email
-            booking_reference: Booking reference number
+            booking_number: Booking reference number
             customer_name: Customer name
             service_name: Service/package name
-            booking_date: Booking date
-            booking_time: Booking time
-            location: Service location
-            total_price: Total price
+            booking_date: Requested booking date
+            location: Service location text
+            subtotal: Service subtotal (transport confirmed later)
+            deposit: Estimated 50% deposit
+            whatsapp_url: Pre-filled wa.me follow-up link (optional)
+            call_number: Business phone for the call button, digits only (optional)
 
         Returns:
             True if sent successfully
         """
-        subject = f"Booking Confirmation - {booking_reference}"
+        subject = f"We've received your booking - {booking_number}"
+
+        # Build the follow-up CTA buttons only when we have contact channels.
+        cta_buttons = ""
+        if whatsapp_url:
+            cta_buttons += (
+                f'<a href="{whatsapp_url}" '
+                'style="display: inline-block; background: #22c55e; color: #ffffff; '
+                'padding: 14px 28px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">Follow up on WhatsApp</a>'
+            )
+        if call_number:
+            cta_buttons += (
+                f'<a href="tel:+{call_number}" '
+                'style="display: inline-block; background: #111827; color: #ffffff; '
+                'padding: 14px 28px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">Call us</a>'
+            )
+        cta_html = (
+            f'<div style="text-align: center; margin: 24px 0;">{cta_buttons}</div>'
+            if cta_buttons
+            else ""
+        )
 
         html_content = f"""
         <!DOCTYPE html>
@@ -319,38 +351,43 @@ class EmailService:
         <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
             <div style="background: linear-gradient(135deg, #000 0%, #333 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
                 <h1 style="margin: 0; font-size: 28px;">Glam by Lynn</h1>
-                <p style="margin: 10px 0 0 0; opacity: 0.9;">Your booking is confirmed!</p>
+                <p style="margin: 10px 0 0 0; opacity: 0.9;">We've received your booking!</p>
             </div>
 
             <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
-                <h2 style="color: #ec4899; margin-top: 0;">Booking Confirmed</h2>
+                <h2 style="color: #ec4899; margin-top: 0;">Thank you, {customer_name}!</h2>
 
-                <p>Hi {customer_name},</p>
-
-                <p>We're excited to see you! Your booking has been confirmed.</p>
+                <p>Your booking request has been received. Here's a summary of what you requested:</p>
 
                 <div style="background: white; padding: 20px; border-radius: 8px; margin: 20px 0;">
-                    <p style="margin: 0;"><strong>Booking Reference:</strong> {booking_reference}</p>
+                    <p style="margin: 0;"><strong>Booking Number:</strong> {booking_number}</p>
                     <p style="margin: 10px 0 0 0;"><strong>Service:</strong> {service_name}</p>
                     <p style="margin: 10px 0 0 0;"><strong>Date:</strong> {booking_date.strftime('%B %d, %Y')}</p>
-                    <p style="margin: 10px 0 0 0;"><strong>Time:</strong> {booking_time}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Time:</strong> To be confirmed</p>
                     <p style="margin: 10px 0 0 0;"><strong>Location:</strong> {location}</p>
-                    <p style="margin: 10px 0 0 0;"><strong>Total:</strong> <span style="color: #ec4899; font-size: 20px; font-weight: bold;">KES {total_price:,.2f}</span></p>
+                    <p style="margin: 10px 0 0 0;"><strong>Service subtotal:</strong> KES {subtotal:,.2f}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Transport:</strong> To be confirmed</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Estimated deposit (50%):</strong> KES {deposit:,.2f}</p>
                 </div>
 
-                <div style="background: #dbeafe; border-left: 4px solid #3b82f6; padding: 15px; margin-top: 30px; border-radius: 4px;">
+                <div style="background: #fdf2f8; border-left: 4px solid #ec4899; padding: 15px; margin-top: 20px; border-radius: 4px;">
                     <p style="margin: 0; font-size: 14px;">
-                        <strong>Important:</strong><br>
-                        Please arrive 10 minutes before your scheduled time. If you need to reschedule or cancel, please contact us at least 24 hours in advance.
+                        <strong>What happens next?</strong><br>
+                        Our team will review your booking and contact you by call or WhatsApp to
+                        confirm availability and your location. We'll then share the final cost
+                        (including transport) and instructions for paying your deposit.
                     </p>
                 </div>
 
-                <p style="margin-top: 30px;">
-                    If you have any questions, please contact us at support@glambylynn.com or call us at +254 XXX XXX XXX
+                {cta_html}
+
+                <p style="text-align: center; color: #666; font-size: 14px; margin-top: 0;">
+                    Have a question or want to follow up? Reach us using the buttons above and
+                    quote your booking number <strong>{booking_number}</strong>.
                 </p>
 
-                <p style="margin-top: 20px; color: #666; font-size: 14px;">
-                    We look forward to seeing you!<br>
+                <p style="margin-top: 30px; color: #666; font-size: 14px;">
+                    Warm regards,<br>
                     <strong style="color: #ec4899;">The Glam by Lynn Team</strong>
                 </p>
             </div>
@@ -363,32 +400,202 @@ class EmailService:
         </html>
         """
 
+        contact_text = ""
+        if whatsapp_url:
+            contact_text += f"\n        Follow up on WhatsApp: {whatsapp_url}"
+        if call_number:
+            contact_text += f"\n        Call us: +{call_number}"
+
         text_content = f"""
-        GLAM BY LYNN - BOOKING CONFIRMATION
+        GLAM BY LYNN - BOOKING RECEIVED
 
         Hi {customer_name},
 
-        Your booking has been confirmed!
+        Your booking request has been received. Here's what you requested:
 
-        Booking Reference: {booking_reference}
+        Booking Number: {booking_number}
         Service: {service_name}
         Date: {booking_date.strftime('%B %d, %Y')}
-        Time: {booking_time}
+        Time: To be confirmed
         Location: {location}
-        Total: KES {total_price:,.2f}
+        Service subtotal: KES {subtotal:,.2f}
+        Transport: To be confirmed
+        Estimated deposit (50%): KES {deposit:,.2f}
 
-        IMPORTANT:
-        Please arrive 10 minutes before your scheduled time. If you need to reschedule or cancel, please contact us at least 24 hours in advance.
+        WHAT HAPPENS NEXT?
+        Our team will review your booking and contact you by call or WhatsApp to confirm
+        availability and your location. We'll then share the final cost (including transport)
+        and instructions for paying your deposit.
 
-        If you have any questions, contact us at support@glambylynn.com or call +254 XXX XXX XXX
+        Want to follow up? Quote your booking number {booking_number}.{contact_text}
 
-        We look forward to seeing you!
-
-        Best regards,
+        Warm regards,
         The Glam by Lynn Team
 
         © {datetime.now().year} Glam by Lynn. All rights reserved.
         Kitui & Nairobi, Kenya
+        """
+
+        return self.send_email(to_email, subject, html_content, text_content)
+
+    def send_booking_admin_notification(
+        self,
+        to_email: str,
+        booking_number: str,
+        customer_name: str,
+        customer_email: str,
+        customer_phone: str,
+        service_name: str,
+        booking_date: datetime,
+        location: str,
+        location_description: Optional[str],
+        attendees: str,
+        subtotal: Decimal,
+        special_requests: Optional[str],
+        admin_url: str,
+        customer_whatsapp_url: Optional[str] = None,
+    ) -> bool:
+        """
+        Notify the admin/team that a new booking needs review.
+
+        Args:
+            to_email: Admin recipient
+            booking_number: Booking reference number
+            customer_name / customer_email / customer_phone: Customer contact
+            service_name: Service/package name
+            booking_date: Requested date
+            location: Location text
+            location_description: Extra location details from the customer
+            attendees: Pre-formatted attendee summary
+            subtotal: Service subtotal (transport set manually later)
+            special_requests: Customer notes
+            admin_url: Link to the booking in the admin dashboard
+            customer_whatsapp_url: Pre-filled wa.me link to message the customer
+
+        Returns:
+            True if sent successfully
+        """
+        subject = f"New booking to review - {booking_number} ({customer_name})"
+
+        phone_digits = re.sub(r"\D", "", customer_phone or "")
+        contact_buttons = (
+            f'<a href="tel:{customer_phone}" '
+            'style="display: inline-block; background: #111827; color: #ffffff; '
+            'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+            'font-weight: bold; margin: 6px;">Call customer</a>'
+            if phone_digits
+            else ""
+        )
+        if customer_whatsapp_url:
+            contact_buttons += (
+                f'<a href="{customer_whatsapp_url}" '
+                'style="display: inline-block; background: #22c55e; color: #ffffff; '
+                'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">WhatsApp customer</a>'
+            )
+        contact_buttons += (
+            f'<a href="{admin_url}" '
+            'style="display: inline-block; background: #ec4899; color: #ffffff; '
+            'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+            'font-weight: bold; margin: 6px;">Open in dashboard</a>'
+        )
+
+        description_row = (
+            f'<p style="margin: 10px 0 0 0;"><strong>Location details:</strong> {location_description}</p>'
+            if location_description
+            else ""
+        )
+        requests_row = (
+            f'<p style="margin: 10px 0 0 0;"><strong>Special requests:</strong> {special_requests}</p>'
+            if special_requests
+            else ""
+        )
+
+        html_content = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #000 0%, #333 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
+                <h1 style="margin: 0; font-size: 28px;">Glam by Lynn</h1>
+                <p style="margin: 10px 0 0 0; opacity: 0.9;">New booking to review</p>
+            </div>
+
+            <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
+                <h2 style="color: #ec4899; margin-top: 0;">Booking {booking_number}</h2>
+
+                <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 15px; border-radius: 4px;">
+                    <p style="margin: 0; font-size: 14px;">
+                        <strong>Action needed:</strong> Review the details below, then contact the
+                        customer to verify availability and location, confirm the transport cost,
+                        and share payment instructions to proceed.
+                    </p>
+                </div>
+
+                <h3 style="color: #333; margin-top: 24px;">Customer</h3>
+                <div style="background: white; padding: 20px; border-radius: 8px;">
+                    <p style="margin: 0;"><strong>Name:</strong> {customer_name}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Email:</strong> {customer_email}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Phone:</strong> {customer_phone}</p>
+                </div>
+
+                <h3 style="color: #333; margin-top: 24px;">Booking</h3>
+                <div style="background: white; padding: 20px; border-radius: 8px;">
+                    <p style="margin: 0;"><strong>Service:</strong> {service_name}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Date:</strong> {booking_date.strftime('%B %d, %Y')}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Time:</strong> To be confirmed with customer</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Location:</strong> {location}</p>
+                    {description_row}
+                    <p style="margin: 10px 0 0 0;"><strong>Attendees:</strong> {attendees}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Service subtotal:</strong> KES {subtotal:,.2f}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Transport:</strong> To be set after location verification</p>
+                    {requests_row}
+                </div>
+
+                <div style="text-align: center; margin: 24px 0;">
+                    {contact_buttons}
+                </div>
+            </div>
+
+            <div style="text-align: center; margin-top: 20px; padding: 20px; color: #666; font-size: 12px;">
+                <p>© {datetime.now().year} Glam by Lynn. Internal notification.</p>
+            </div>
+        </body>
+        </html>
+        """
+
+        text_content = f"""
+        GLAM BY LYNN - NEW BOOKING TO REVIEW
+
+        Booking Number: {booking_number}
+
+        ACTION NEEDED:
+        Review the details below, then contact the customer to verify availability and
+        location, confirm the transport cost, and share payment instructions.
+
+        CUSTOMER
+        Name: {customer_name}
+        Email: {customer_email}
+        Phone: {customer_phone}
+
+        BOOKING
+        Service: {service_name}
+        Date: {booking_date.strftime('%B %d, %Y')}
+        Time: To be confirmed with customer
+        Location: {location}
+        {f'Location details: {location_description}' if location_description else ''}
+        Attendees: {attendees}
+        Service subtotal: KES {subtotal:,.2f}
+        Transport: To be set after location verification
+        {f'Special requests: {special_requests}' if special_requests else ''}
+
+        Open in dashboard: {admin_url}
+        {f'WhatsApp customer: {customer_whatsapp_url}' if customer_whatsapp_url else ''}
+
+        © {datetime.now().year} Glam by Lynn. Internal notification.
         """
 
         return self.send_email(to_email, subject, html_content, text_content)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,9 @@ pydantic>=2.5.3
 pydantic-settings>=2.1.0
 email-validator>=2.1.0
 
+# Email
+resend>=2.0.0
+
 # Environment variables
 python-dotenv>=1.0.0
 

--- a/frontend/src/app/bookings/[id]/confirmation/page.tsx
+++ b/frontend/src/app/bookings/[id]/confirmation/page.tsx
@@ -19,7 +19,6 @@ import {
   getBookingConfirmation,
   formatCurrency,
   formatDate,
-  formatTime,
 } from "@/lib/bookings";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -210,9 +209,9 @@ export default function BookingConfirmationPage() {
                 </div>
                 <div className="space-y-1">
                   <p className="text-sm text-muted-foreground">Time</p>
-                  <p className="flex items-center gap-2 font-medium">
+                  <p className="flex items-center gap-2 font-medium text-muted-foreground">
                     <Clock className="h-4 w-4" />
-                    {formatTime(booking.bookingTime)}
+                    To be confirmed
                   </p>
                 </div>
                 <div className="space-y-1">

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -160,8 +160,10 @@ function BookingFormContent() {
       case 3:
         return attendeeErrors.length === 0;
       case 4:
+        // Accounts don't store a phone number, so we require it here even for
+        // signed-in users — it's how we reach them about the booking.
         return user
-          ? true
+          ? isValidPhone(guestPhone)
           : !!guestName.trim() &&
               isValidEmail(guestEmail) &&
               isValidPhone(guestPhone);
@@ -176,10 +178,11 @@ function BookingFormContent() {
     selectedPackageId &&
     hasValidLocation &&
     bookingDate &&
-    (user ||
-      (guestName.trim() &&
+    (user
+      ? isValidPhone(guestPhone)
+      : guestName.trim() &&
         isValidEmail(guestEmail) &&
-        isValidPhone(guestPhone))) &&
+        isValidPhone(guestPhone)) &&
     pricing &&
     pricing.total > 0;
 
@@ -251,10 +254,12 @@ function BookingFormContent() {
         num_others: numOthers,
         wedding_theme: weddingTheme || undefined,
         special_requests: specialRequests || undefined,
+        // Phone is always captured (accounts have no phone field); name/email
+        // only for guests — signed-in bookings use the account for those.
+        guest_phone: normalizePhone(guestPhone),
         ...(!user && {
           guest_name: guestName.trim(),
           guest_email: guestEmail.trim(),
-          guest_phone: normalizePhone(guestPhone),
         }),
       };
 
@@ -723,12 +728,48 @@ function BookingFormContent() {
             </p>
 
             {user ? (
-              <Card>
-                <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Signed in as</p>
-                  <p className="font-medium">{user.email}</p>
-                </CardContent>
-              </Card>
+              <div className="space-y-4">
+                <Card>
+                  <CardContent className="p-5">
+                    <p className="text-sm text-muted-foreground">
+                      Signed in as
+                    </p>
+                    {user.name && (
+                      <p className="font-medium">{user.name}</p>
+                    )}
+                    <p className={user.name ? "text-muted-foreground" : "font-medium"}>
+                      {user.email}
+                    </p>
+                  </CardContent>
+                </Card>
+                <div className="space-y-2">
+                  <Label htmlFor="guestPhone">Phone Number *</Label>
+                  <Input
+                    id="guestPhone"
+                    type="tel"
+                    placeholder="+254 7XX XXX XXX"
+                    value={guestPhone}
+                    onChange={(e) => setGuestPhone(e.target.value)}
+                    aria-invalid={
+                      guestPhone.length > 0 && !isValidPhone(guestPhone)
+                    }
+                    className="sm:max-w-xs"
+                    required
+                  />
+                  {guestPhone.length > 0 && !isValidPhone(guestPhone) ? (
+                    <p className="text-xs text-destructive">
+                      Enter a Kenyan mobile number, e.g. +254 712 345 678 or
+                      0712 345 678.
+                    </p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      We&apos;ll use this to confirm your booking and reach you
+                      on WhatsApp or by call. Kenyan mobile: +254 7XX XXX XXX or
+                      07XX XXX XXX.
+                    </p>
+                  )}
+                </div>
+              </div>
             ) : (
               <div className="space-y-4">
                 <div className="space-y-2">
@@ -937,8 +978,8 @@ function BookingFormContent() {
                 </CardContent>
               </Card>
 
-              {/* Contact Info (guest) */}
-              {!user && guestName && (
+              {/* Contact Info */}
+              {(user || guestName) && (
                 <Card>
                   <CardContent className="p-5">
                     <div className="mb-3 flex items-center justify-between">
@@ -955,10 +996,16 @@ function BookingFormContent() {
                     </div>
                     <div className="space-y-1 text-sm">
                       <p>
-                        Name: <span className="font-medium">{guestName}</span>
+                        Name:{" "}
+                        <span className="font-medium">
+                          {user ? user.name || "—" : guestName}
+                        </span>
                       </p>
                       <p>
-                        Email: <span className="font-medium">{guestEmail}</span>
+                        Email:{" "}
+                        <span className="font-medium">
+                          {user ? user.email : guestEmail}
+                        </span>
                       </p>
                       <p>
                         Phone: <span className="font-medium">{guestPhone}</span>

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -23,7 +23,6 @@ import {
   calculateBookingPrice,
   formatCurrency,
   formatDate,
-  formatTime,
 } from "@/lib/bookings";
 import { LocationAutocomplete } from "@/components/LocationAutocomplete";
 import { useAuth } from "@/hooks/useAuth";
@@ -235,15 +234,13 @@ function BookingFormContent() {
       setSubmitting(true);
       setError(null);
 
-      // Split the datetime-local value into the date + time fields the
-      // backend expects (HH:MM → HH:MM:SS).
-      const [datePart, timePart = ""] = bookingDate.split("T");
-      const submitTime = timePart ? `${timePart}:00` : "";
-
+      // The picker now collects a date only; the exact appointment time is
+      // confirmed with the customer after booking. Send a neutral placeholder
+      // for the time the backend still requires.
       const bookingData = {
         package_id: selectedPackageId,
-        booking_date: datePart,
-        booking_time: submitTime,
+        booking_date: bookingDate,
+        booking_time: "09:00:00",
         custom_location_address: customLocation!.address,
         custom_location_latitude: customLocation!.latitude,
         custom_location_longitude: customLocation!.longitude,
@@ -473,21 +470,25 @@ function BookingFormContent() {
             {/* Date & Time Selection */}
             <div className="mb-6">
               <Label htmlFor="date" className="mb-2 block text-base font-medium">
-                Preferred Date & Time *
+                Preferred Date *
               </Label>
               <Input
                 id="date"
-                type="datetime-local"
+                type="date"
                 value={bookingDate}
                 onChange={(e) => setBookingDate(e.target.value)}
                 min={(() => {
                   const now = new Date();
                   now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-                  return now.toISOString().slice(0, 16);
+                  return now.toISOString().slice(0, 10);
                 })()}
                 className="max-w-xs"
                 required
               />
+              <p className="mt-2 text-sm text-muted-foreground">
+                We&apos;ll confirm the exact appointment time with you after your
+                booking.
+              </p>
             </div>
 
             {/* Location Selection */}
@@ -845,7 +846,7 @@ function BookingFormContent() {
                 <CardContent className="p-5">
                   <div className="mb-3 flex items-center justify-between">
                     <h3 className="font-semibold text-muted-foreground">
-                      Date, Time & Location
+                      Date & Location
                     </h3>
                     <button
                       type="button"
@@ -862,8 +863,8 @@ function BookingFormContent() {
                     </div>
                     <div className="flex items-center gap-2">
                       <Clock className="h-4 w-4 text-muted-foreground" />
-                      <span>
-                        {formatTime(bookingDate.split("T")[1] || "")}
+                      <span className="text-muted-foreground">
+                        Time to be confirmed
                       </span>
                     </div>
                     <div className="flex items-start gap-2">
@@ -1032,40 +1033,55 @@ function BookingFormContent() {
                 <ChevronLeft className="mr-2 h-4 w-4" />
                 Back
               </Button>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
-                {selectedPackage && (
-                  <WhatsAppButton
-                    variant="outline"
-                    size="lg"
-                    label="Book on WhatsApp"
-                    className="sm:flex-1"
-                    context={{
-                      type: "service",
-                      service_id: selectedPackage.id,
-                      preferred_date: bookingDate || undefined,
-                    }}
-                  />
+              <Button
+                onClick={handleSubmit}
+                disabled={!canSubmit || attendeeErrors.length > 0 || submitting}
+                size="lg"
+                className="w-full sm:w-auto sm:min-w-[200px]"
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Confirming Booking...
+                  </>
+                ) : (
+                  "Confirm Booking"
                 )}
-                <Button
-                  onClick={handleSubmit}
-                  disabled={!canSubmit || attendeeErrors.length > 0 || submitting}
-                  size="lg"
-                  className="w-full sm:w-auto sm:flex-1"
-                >
-                  {submitting ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Confirming Booking...
-                    </>
-                  ) : (
-                    "Confirm Booking"
-                  )}
-                </Button>
-              </div>
+              </Button>
             </div>
           </div>
         )}
       </main>
+
+      {/* Persistent WhatsApp escape hatch — always visible across every step so
+          users who'd rather not finish the form can hand off to our team
+          instead of abandoning the booking. Carries the service + date they've
+          chosen so far. */}
+      <div className="sticky bottom-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="container mx-auto max-w-4xl px-4 py-3">
+          <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
+            <p className="text-center text-sm text-muted-foreground sm:text-left">
+              Prefer to book over chat? Our team can complete it with you on
+              WhatsApp.
+            </p>
+            <WhatsAppButton
+              variant="outline"
+              size="default"
+              label="Book on WhatsApp"
+              className="w-full sm:w-auto sm:min-w-[200px]"
+              context={
+                selectedPackage
+                  ? {
+                      type: "service",
+                      service_id: selectedPackage.id,
+                      preferred_date: bookingDate || undefined,
+                    }
+                  : { type: "general" }
+              }
+            />
+          </div>
+        </div>
+      </div>
 
       <Footer />
     </div>

--- a/frontend/src/components/WhatsAppFloatingButton.tsx
+++ b/frontend/src/components/WhatsAppFloatingButton.tsx
@@ -8,6 +8,9 @@ export function WhatsAppFloatingButton() {
   const pathname = usePathname() ?? "";
 
   if (pathname.startsWith("/admin")) return null;
+  // The booking wizard renders its own persistent, context-aware
+  // "Book on WhatsApp" bar, so suppress the generic bubble there.
+  if (pathname.startsWith("/bookings/new")) return null;
 
   return (
     <div className="fixed bottom-5 right-5 z-50 sm:bottom-6 sm:right-6">


### PR DESCRIPTION
## Summary

Continues the guest-first booking work with UX, communication, and data-capture improvements across the service booking flow.

### 1. Friendlier date picker
- Replaced the fiddly `datetime-local` picker in **Date & Location** with a plain **date** input — the exact appointment time is confirmed with the customer after booking.
- Review and confirmation pages now show **"Time to be confirmed"** instead of a placeholder time.

### 2. Persistent "Book on WhatsApp" option
- Added a **sticky, context-aware bar** visible on *every* step so hesitant users can hand off to the team instead of abandoning the form. It carries the selected service + date (falls back to a general chat).
- Hid the global WhatsApp bubble on `/bookings/new` to avoid a duplicate CTA, and removed the now-redundant button from the review step.

### 3. Booking notification emails (customer + team)
On booking creation, two transactional emails fan out via background tasks (never blocking or failing the booking):
- **Customer** — *"We've received your booking"* (pending, not "confirmed"), with a clear *what happens next* and prominent **Follow up on WhatsApp** + **Call us** buttons. The number comes from settings, never hard-coded.
- **Team** — *"New booking to review"* with full customer contact, an explicit action checklist (verify availability/location → confirm transport → share payment instructions), and **Call customer** / **WhatsApp customer** (points at the customer's normalised KE number) / **Open in dashboard** buttons. Sent to each `ADMIN_EMAILS` address.
- Replaced the unused, misleading `send_booking_confirmation` that didn't match the verify-then-confirm flow.

### 4. Require phone from signed-in users
- Accounts have no phone field, but it's essential for follow-up. At the contact step, signed-in users now see their **name + email pre-populated read-only** from the account and must enter a **phone number** (same KE validation as guests). The phone is always sent and stored on the booking so the notification emails can reach them.

## Testing
- Frontend `tsc --noEmit` clean; booking page compiles and serves 200.
- Created guest bookings against a live backend and confirmed both customer and admin emails render correctly (console mailer), including the WhatsApp follow-up link, **Call us** number, and the admin's **WhatsApp customer** link pointing at the customer's normalised number (`0722333444` → `254722333444`).
- Verified the backend persists `guest_phone` on authenticated bookings, so signed-in bookings also get a reachable phone in the emails.

## Notes
- In production set `EMAIL_PROVIDER=resend` (+`RESEND_API_KEY`) and populate `ADMIN_EMAILS`; locally it defaults to the console provider.
- The admin email's "Open in dashboard" links to `/admin/bookings` (the existing list); a per-booking admin detail route could deep-link it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)