### PR TITLE
chore(email): surface send failures in logs instead of swallowing them

### DIFF
--- a/backend/app/services/booking_notifications.py
+++ b/backend/app/services/booking_notifications.py
@@ -6,6 +6,7 @@ FastAPI background tasks so a slow or failing mail provider never blocks
 (or fails) the booking itself.
 """
 import json
+import logging
 import re
 from decimal import Decimal
 from typing import List, Optional
@@ -18,6 +19,8 @@ from app.core.config import settings
 from app.models.booking import Booking
 from app.services import site_settings_service
 from app.services.email_service import email_service
+
+logger = logging.getLogger(__name__)
 
 PHONE_KEY = "whatsapp_phone_number"
 
@@ -139,6 +142,10 @@ def schedule_booking_notifications(
 
     # Customer notification
     if customer_email:
+        logger.info(
+            "Queuing customer booking email for %s (booking=%s)",
+            customer_email, booking.booking_number,
+        )
         background_tasks.add_task(
             email_service.send_booking_received_customer,
             to_email=customer_email,
@@ -151,6 +158,11 @@ def schedule_booking_notifications(
             deposit=deposit,
             whatsapp_url=followup_url,
             call_number=phone,
+        )
+    else:
+        logger.warning(
+            "No customer email for booking %s — skipping customer notification",
+            booking.booking_number,
         )
 
     # Admin notification(s)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,9 +1,12 @@
 """Email service for sending transactional emails."""
+import logging
 import os
 import re
 from typing import Optional, Dict, Any
 from datetime import datetime
 from decimal import Decimal
+
+logger = logging.getLogger(__name__)
 
 # Import email libraries based on availability
 try:
@@ -72,13 +75,20 @@ class EmailService:
                 return True
 
             elif self.provider == "resend":
-                resend.Emails.send({
+                response = resend.Emails.send({
                     "from": f"{self.from_name} <{self.from_email}>",
                     "to": to_email,
                     "subject": subject,
                     "html": html_content,
                     "text": text_content,
                 })
+                # Resend returns {"id": "..."} on success; surface it so a
+                # send can be traced in the provider dashboard.
+                message_id = response.get("id") if isinstance(response, dict) else None
+                logger.info(
+                    "Email sent via resend to %s (subject=%r, id=%s)",
+                    to_email, subject, message_id,
+                )
                 return True
 
             elif self.provider == "sendgrid":
@@ -91,14 +101,27 @@ class EmailService:
                 )
                 sg = SendGridAPIClient(self.sendgrid_key)
                 sg.send(message)
+                logger.info(
+                    "Email sent via sendgrid to %s (subject=%r)", to_email, subject
+                )
                 return True
 
             else:
-                print(f"Unknown email provider: {self.provider}")
+                logger.error(
+                    "Unknown email provider %r — cannot send to %s (subject=%r)",
+                    self.provider, to_email, subject,
+                )
                 return False
 
         except Exception as e:
-            print(f"Error sending email: {e}")
+            # Log the recipient and the provider error with a traceback. This is
+            # the only place a per-recipient failure (e.g. Resend rejecting a
+            # non-verified-domain recipient) becomes visible — without it the
+            # caller just sees False and the failure is silent.
+            logger.exception(
+                "Failed to send email via %s to %s (subject=%r): %s",
+                self.provider, to_email, subject, e,
+            )
             return False
 
     def send_order_confirmation(


### PR DESCRIPTION
## Why

When the deployed site sent a booking, the admin email arrived but the customer email didn't — and there was **no trace of why**. Root cause of the silence: `send_email()` caught every exception and just `print`ed a generic "Error sending email", so a per-recipient provider rejection (the classic Resend "you can only send to your own address until you verify a domain") vanished without a usable log.

## Changes

- **`email_service.send_email`**: switched to a module logger.
  - On failure: `logger.exception(...)` with the **provider, recipient, subject, and full traceback** — the real error is now visible.
  - On success: `logger.info(...)` with the recipient and the **Resend message id** for dashboard traceability.
  - Unknown provider: logs an error instead of a bare print.
- **`booking_notifications`**: logs when a customer email is **queued**, and `logger.warning(...)` when it's **skipped** because no customer email could be resolved (the other silent gap).

## Testing

Exercised the failure paths directly:
```
ERROR ... Failed to send email via resend to customer@example.com (subject='Test subject'): API key is invalid
<full traceback>
ERROR ... Unknown email provider 'bogus' — cannot send to x@example.com (subject='S')
```
Both return `False` (non-fatal) as before — only now the reason is logged. Modules import cleanly and the backend reloads without error.

> Note: this is purely observability. The actual customer-delivery fix is still verifying the Resend domain and setting `EMAIL_FROM` to an address on it — but now any future failure will say exactly why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)