### PR TITLE
feat(checkout): align product checkout with booking flow (phone, emails, payment config)

### DIFF
--- a/backend/EMAIL_SETUP.md
+++ b/backend/EMAIL_SETUP.md
@@ -78,10 +78,15 @@ SENDGRID_API_KEY=your_sendgrid_api_key_here
 
 The service includes responsive HTML templates for:
 
-### 1. Order Confirmation Email
-- Sent when customer places an order
-- Includes order details, items, totals, delivery address
-- Brand colors: Black background with pink accents
+### 1. Order Notification Emails
+Sent automatically when an order is created (via FastAPI background tasks, so a
+slow/failing provider never blocks or fails the order):
+- **Customer** (`send_order_confirmation`) — confirms the order, summarises
+  items/totals/delivery address, explains what happens next, and offers
+  "Follow up on WhatsApp" + "Call us" buttons.
+- **Team** (`send_order_admin_notification`) — sent to each `ADMIN_EMAILS`
+  address with the customer's contact, order details, and "Call customer" /
+  "WhatsApp customer" / "Open in dashboard" buttons.
 
 ### 2. Booking Notification Emails
 Sent automatically when a booking is created (via FastAPI background tasks, so

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -1,7 +1,7 @@
 """Order API routes."""
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -21,6 +21,7 @@ router = APIRouter(tags=["Orders"])
 )
 def create_order(
     order_data: OrderCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: Optional[User] = Depends(get_optional_current_user),
 ):
@@ -46,6 +47,8 @@ def create_order(
         promo_code=order_data.promo_code,
         payment_method=order_data.payment_method,
         cart_items=order_data.cart_items,
+        contact_phone=order_data.contact_phone,
+        background_tasks=background_tasks,
     )
 
     if not success:

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -69,6 +69,9 @@ class OrderCreate(BaseModel):
     delivery_info: DeliveryInfo = Field(..., alias="deliveryInfo")
     promo_code: Optional[str] = Field(None, alias="promoCode")
     payment_method: Optional[str] = Field(None, alias="paymentMethod")
+    # Contact phone for authenticated checkout (accounts store no phone).
+    # Guests supply theirs via guest_info instead.
+    contact_phone: Optional[str] = Field(None, alias="contactPhone")
 
     class Config:
         populate_by_name = True

--- a/backend/app/services/booking_notifications.py
+++ b/backend/app/services/booking_notifications.py
@@ -5,37 +5,23 @@ request's DB session is still open, then schedules the actual sends on
 FastAPI background tasks so a slow or failing mail provider never blocks
 (or fails) the booking itself.
 """
-import json
 import logging
-import re
 from decimal import Decimal
-from typing import List, Optional
-from urllib.parse import quote
+from typing import List
 
 from fastapi import BackgroundTasks
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.models.booking import Booking
-from app.services import site_settings_service
 from app.services.email_service import email_service
+from app.services.notifications_common import (
+    customer_contact_url,
+    followup_url,
+    resolve_business_phone,
+)
 
 logger = logging.getLogger(__name__)
-
-PHONE_KEY = "whatsapp_phone_number"
-
-
-def _resolve_business_phone(db: Session) -> Optional[str]:
-    """Return the configured WhatsApp/business number as digits, or None."""
-    raw = site_settings_service.get_setting(db, PHONE_KEY)
-    if not raw:
-        return None
-    try:
-        value = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        value = raw
-    digits = re.sub(r"\D", "", str(value))
-    return digits if 8 <= len(digits) <= 15 else None
 
 
 def _booking_followup_url(phone: str, booking_number: str) -> str:
@@ -44,39 +30,7 @@ def _booking_followup_url(phone: str, booking_number: str) -> str:
         "Hi Glam by Lynn — I'd like to follow up on my booking.\n"
         f"Booking number: {booking_number}"
     )
-    return f"https://wa.me/{phone}?text={quote(message)}"
-
-
-def _normalize_ke_phone(phone: str) -> Optional[str]:
-    """Normalise a Kenyan phone number to wa.me digits (2547XXXXXXXX).
-
-    Accepts 07XXXXXXXX / 01XXXXXXXX, +2547XXXXXXXX, or 2547XXXXXXXX.
-    Returns None if it doesn't look like a usable number.
-    """
-    digits = re.sub(r"\D", "", phone or "")
-    if digits.startswith("0") and len(digits) == 10:
-        digits = "254" + digits[1:]
-    elif digits.startswith("254") and len(digits) == 12:
-        pass
-    elif digits.startswith("7") or digits.startswith("1"):
-        if len(digits) == 9:
-            digits = "254" + digits
-    return digits if 11 <= len(digits) <= 15 else None
-
-
-def _customer_contact_url(customer_phone: str, customer_name: str, booking_number: str) -> Optional[str]:
-    """wa.me link the team can use to message the customer about a booking.
-
-    Points at the *customer's* number so the chat opens with them.
-    """
-    normalized = _normalize_ke_phone(customer_phone)
-    if not normalized:
-        return None
-    message = (
-        f"Hi {customer_name}, this is Glam by Lynn regarding your booking "
-        f"{booking_number}."
-    )
-    return f"https://wa.me/{normalized}?text={quote(message)}"
+    return followup_url(phone, message)
 
 
 def _format_attendees(booking: Booking) -> str:
@@ -129,12 +83,14 @@ def schedule_booking_notifications(
     subtotal = Decimal(booking.subtotal or 0)
     deposit = Decimal(booking.deposit_amount or 0)
 
-    phone = _resolve_business_phone(db)
-    followup_url = (
+    phone = resolve_business_phone(db)
+    booking_followup_url = (
         _booking_followup_url(phone, booking.booking_number) if phone else None
     )
     customer_wa_url = (
-        _customer_contact_url(customer_phone, customer_name, booking.booking_number)
+        customer_contact_url(
+            customer_phone, customer_name, f"booking {booking.booking_number}"
+        )
         if customer_phone
         else None
     )
@@ -156,7 +112,7 @@ def schedule_booking_notifications(
             location=location,
             subtotal=subtotal,
             deposit=deposit,
-            whatsapp_url=followup_url,
+            whatsapp_url=booking_followup_url,
             call_number=phone,
         )
     else:

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -135,6 +135,8 @@ class EmailService:
         delivery_fee: Decimal,
         total: Decimal,
         delivery_address: Dict[str, Any],
+        whatsapp_url: Optional[str] = None,
+        call_number: Optional[str] = None,
     ) -> bool:
         """
         Send order confirmation email.
@@ -149,11 +151,37 @@ class EmailService:
             delivery_fee: Delivery fee
             total: Total amount
             delivery_address: Delivery address details
+            whatsapp_url: Pre-filled wa.me follow-up link (optional)
+            call_number: Business phone for the call button, digits only (optional)
 
         Returns:
             True if sent successfully
         """
         subject = f"Order Confirmation - {order_number}"
+
+        # Build the follow-up CTA buttons only when we have contact channels,
+        # mirroring the booking-received email so customers can reach us
+        # straight from their inbox instead of waiting passively.
+        cta_buttons = ""
+        if whatsapp_url:
+            cta_buttons += (
+                f'<a href="{whatsapp_url}" '
+                'style="display: inline-block; background: #22c55e; color: #ffffff; '
+                'padding: 14px 28px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">Follow up on WhatsApp</a>'
+            )
+        if call_number:
+            cta_buttons += (
+                f'<a href="tel:+{call_number}" '
+                'style="display: inline-block; background: #111827; color: #ffffff; '
+                'padding: 14px 28px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">Call us</a>'
+            )
+        cta_html = (
+            f'<div style="text-align: center; margin: 24px 0;">{cta_buttons}</div>'
+            if cta_buttons
+            else ""
+        )
 
         # Build items HTML
         items_html = ""
@@ -243,12 +271,16 @@ class EmailService:
                 <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 15px; margin-top: 30px; border-radius: 4px;">
                     <p style="margin: 0; font-size: 14px;">
                         <strong>What's Next?</strong><br>
-                        We'll send you another email once your order ships with tracking information.
+                        Our team will be in touch to arrange payment and delivery. We'll send
+                        another email once your order ships with tracking information.
                     </p>
                 </div>
 
+                {cta_html}
+
                 <p style="margin-top: 30px;">
-                    If you have any questions about your order, please contact us at support@glambylynn.com
+                    Have a question about your order? Reach us using the buttons above and
+                    quote your order number <strong>{order_number}</strong>.
                 </p>
 
                 <p style="margin-top: 20px; color: #666; font-size: 14px;">
@@ -291,15 +323,202 @@ class EmailService:
         {delivery_address.get('city', '')}, {delivery_address.get('county', '')}
 
         What's Next?
-        We'll send you another email once your order ships with tracking information.
+        Our team will be in touch to arrange payment and delivery. We'll send another
+        email once your order ships with tracking information.
 
-        If you have any questions, contact us at support@glambylynn.com
+        Have a question? Quote your order number {order_number}.{(chr(10) + '        Follow up on WhatsApp: ' + whatsapp_url) if whatsapp_url else ''}{(chr(10) + '        Call us: +' + call_number) if call_number else ''}
 
         Best regards,
         The Glam by Lynn Team
 
         © {datetime.now().year} Glam by Lynn. All rights reserved.
         Kitui & Nairobi, Kenya
+        """
+
+        return self.send_email(to_email, subject, html_content, text_content)
+
+    def send_order_admin_notification(
+        self,
+        to_email: str,
+        order_number: str,
+        customer_name: str,
+        customer_email: str,
+        customer_phone: str,
+        order_items: list,
+        subtotal: Decimal,
+        discount: Decimal,
+        delivery_fee: Decimal,
+        total: Decimal,
+        delivery_address: Dict[str, Any],
+        admin_url: str,
+        customer_whatsapp_url: Optional[str] = None,
+    ) -> bool:
+        """
+        Notify the admin/team that a new order needs to be processed.
+
+        Mirrors send_booking_admin_notification: order + customer details plus
+        Call / WhatsApp customer and open-in-dashboard action buttons.
+
+        Args:
+            to_email: Admin recipient
+            order_number: Order reference number
+            customer_name / customer_email / customer_phone: Customer contact
+            order_items: List of order items with product details
+            subtotal / discount / delivery_fee / total: Order totals
+            delivery_address: Delivery address details (address/city/county)
+            admin_url: Link to the order in the admin dashboard
+            customer_whatsapp_url: Pre-filled wa.me link to message the customer
+
+        Returns:
+            True if sent successfully
+        """
+        subject = f"New order to process - {order_number} ({customer_name})"
+
+        items_html = ""
+        for item in order_items:
+            items_html += f"""
+            <tr>
+                <td style="padding: 10px; border-bottom: 1px solid #eee;">
+                    {item.get('product_title', 'Product')}
+                    {f"({item.get('variant_name', '')})" if item.get('variant_name') else ''}
+                </td>
+                <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: center;">
+                    {item.get('quantity', 1)}
+                </td>
+                <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: right;">
+                    KES {item.get('total_price', 0):,.2f}
+                </td>
+            </tr>
+            """
+
+        phone_digits = re.sub(r"\D", "", customer_phone or "")
+        contact_buttons = (
+            f'<a href="tel:{customer_phone}" '
+            'style="display: inline-block; background: #111827; color: #ffffff; '
+            'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+            'font-weight: bold; margin: 6px;">Call customer</a>'
+            if phone_digits
+            else ""
+        )
+        if customer_whatsapp_url:
+            contact_buttons += (
+                f'<a href="{customer_whatsapp_url}" '
+                'style="display: inline-block; background: #22c55e; color: #ffffff; '
+                'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+                'font-weight: bold; margin: 6px;">WhatsApp customer</a>'
+            )
+        contact_buttons += (
+            f'<a href="{admin_url}" '
+            'style="display: inline-block; background: #ec4899; color: #ffffff; '
+            'padding: 12px 22px; border-radius: 8px; text-decoration: none; '
+            'font-weight: bold; margin: 6px;">Open in dashboard</a>'
+        )
+
+        discount_row = (
+            f'<p style="margin: 10px 0 0 0;"><strong>Discount:</strong> -KES {discount:,.2f}</p>'
+            if discount > 0
+            else ""
+        )
+
+        html_content = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #000 0%, #333 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
+                <h1 style="margin: 0; font-size: 28px;">Glam by Lynn</h1>
+                <p style="margin: 10px 0 0 0; opacity: 0.9;">New order to process</p>
+            </div>
+
+            <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
+                <h2 style="color: #ec4899; margin-top: 0;">Order {order_number}</h2>
+
+                <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 15px; border-radius: 4px;">
+                    <p style="margin: 0; font-size: 14px;">
+                        <strong>Action needed:</strong> Review the order below, then contact the
+                        customer to confirm payment and arrange delivery.
+                    </p>
+                </div>
+
+                <h3 style="color: #333; margin-top: 24px;">Customer</h3>
+                <div style="background: white; padding: 20px; border-radius: 8px;">
+                    <p style="margin: 0;"><strong>Name:</strong> {customer_name}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Email:</strong> {customer_email}</p>
+                    <p style="margin: 10px 0 0 0;"><strong>Phone:</strong> {customer_phone}</p>
+                </div>
+
+                <h3 style="color: #333; margin-top: 24px;">Order Items</h3>
+                <table style="width: 100%; background: white; border-radius: 8px; overflow: hidden; border-collapse: collapse;">
+                    <thead>
+                        <tr style="background: #f3f4f6;">
+                            <th style="padding: 10px; text-align: left;">Product</th>
+                            <th style="padding: 10px; text-align: center;">Qty</th>
+                            <th style="padding: 10px; text-align: right;">Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items_html}
+                    </tbody>
+                </table>
+
+                <div style="background: white; padding: 20px; border-radius: 8px; margin-top: 20px;">
+                    <p style="margin: 0;"><strong>Subtotal:</strong> KES {subtotal:,.2f}</p>
+                    {discount_row}
+                    <p style="margin: 10px 0 0 0;"><strong>Delivery Fee:</strong> KES {delivery_fee:,.2f}</p>
+                    <p style="margin: 10px 0 0 0; font-size: 18px;"><strong>Total:</strong> <span style="color: #ec4899;">KES {total:,.2f}</span></p>
+                </div>
+
+                <h3 style="color: #333; margin-top: 24px;">Delivery Address</h3>
+                <div style="background: white; padding: 20px; border-radius: 8px;">
+                    <p style="margin: 0;">{delivery_address.get('address', '')}</p>
+                    <p style="margin: 5px 0 0 0;">{delivery_address.get('city', '')}, {delivery_address.get('county', '')}</p>
+                </div>
+
+                <div style="text-align: center; margin: 24px 0;">
+                    {contact_buttons}
+                </div>
+            </div>
+
+            <div style="text-align: center; margin-top: 20px; padding: 20px; color: #666; font-size: 12px;">
+                <p>© {datetime.now().year} Glam by Lynn. Internal notification.</p>
+            </div>
+        </body>
+        </html>
+        """
+
+        text_content = f"""
+        GLAM BY LYNN - NEW ORDER TO PROCESS
+
+        Order Number: {order_number}
+
+        ACTION NEEDED:
+        Review the order below, then contact the customer to confirm payment and
+        arrange delivery.
+
+        CUSTOMER
+        Name: {customer_name}
+        Email: {customer_email}
+        Phone: {customer_phone}
+
+        ORDER ITEMS:
+        {chr(10).join([f"        - {item.get('product_title', 'Product')} x{item.get('quantity', 1)} - KES {item.get('total_price', 0):,.2f}" for item in order_items])}
+
+        SUMMARY:
+        Subtotal: KES {subtotal:,.2f}
+        {'Discount: -KES ' + f'{discount:,.2f}' if discount > 0 else ''}
+        Delivery Fee: KES {delivery_fee:,.2f}
+        Total: KES {total:,.2f}
+
+        DELIVERY ADDRESS:
+        {delivery_address.get('address', '')}
+        {delivery_address.get('city', '')}, {delivery_address.get('county', '')}
+
+        Open in dashboard: {admin_url}
+
+        © {datetime.now().year} Glam by Lynn. Internal notification.
         """
 
         return self.send_email(to_email, subject, html_content, text_content)

--- a/backend/app/services/notifications_common.py
+++ b/backend/app/services/notifications_common.py
@@ -1,0 +1,68 @@
+"""Shared helpers for customer/admin notification emails.
+
+Both booking and order notifications resolve the same things — the business
+WhatsApp number, a Kenyan phone normalised for wa.me links, and a deep link to
+message the customer. Keep that logic here so the two flows stay in sync.
+"""
+import json
+import re
+from typing import Optional
+from urllib.parse import quote
+
+from sqlalchemy.orm import Session
+
+from app.services import site_settings_service
+
+PHONE_KEY = "whatsapp_phone_number"
+
+
+def resolve_business_phone(db: Session) -> Optional[str]:
+    """Return the configured WhatsApp/business number as digits, or None."""
+    raw = site_settings_service.get_setting(db, PHONE_KEY)
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        value = raw
+    digits = re.sub(r"\D", "", str(value))
+    return digits if 8 <= len(digits) <= 15 else None
+
+
+def normalize_ke_phone(phone: str) -> Optional[str]:
+    """Normalise a Kenyan phone number to wa.me digits (2547XXXXXXXX).
+
+    Accepts 07XXXXXXXX / 01XXXXXXXX, +2547XXXXXXXX, or 2547XXXXXXXX.
+    Returns None if it doesn't look like a usable number.
+    """
+    digits = re.sub(r"\D", "", phone or "")
+    if digits.startswith("0") and len(digits) == 10:
+        digits = "254" + digits[1:]
+    elif digits.startswith("254") and len(digits) == 12:
+        pass
+    elif digits.startswith("7") or digits.startswith("1"):
+        if len(digits) == 9:
+            digits = "254" + digits
+    return digits if 11 <= len(digits) <= 15 else None
+
+
+def customer_contact_url(
+    customer_phone: str, customer_name: str, reference: str
+) -> Optional[str]:
+    """wa.me link the team can use to message the customer.
+
+    Points at the *customer's* number so the chat opens with them. ``reference``
+    is the booking or order number to mention.
+    """
+    normalized = normalize_ke_phone(customer_phone)
+    if not normalized:
+        return None
+    message = (
+        f"Hi {customer_name}, this is Glam by Lynn regarding your {reference}."
+    )
+    return f"https://wa.me/{normalized}?text={quote(message)}"
+
+
+def followup_url(phone: str, message: str) -> str:
+    """wa.me link a customer can use to follow up, pointed at the business."""
+    return f"https://wa.me/{phone}?text={quote(message)}"

--- a/backend/app/services/order_notifications.py
+++ b/backend/app/services/order_notifications.py
@@ -1,0 +1,138 @@
+"""Order notification orchestration.
+
+Gathers everything the customer- and admin-facing order emails need while the
+request's DB session is still open, then schedules the actual sends on FastAPI
+background tasks so a slow or failing mail provider never blocks (or fails) the
+order itself. Mirrors ``booking_notifications`` so the two flows stay in sync.
+"""
+import logging
+from decimal import Decimal
+from typing import List, Optional
+
+from fastapi import BackgroundTasks
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.order import Order
+from app.models.user import User
+from app.schemas.order import DeliveryInfo, GuestInfo
+from app.services.email_service import email_service
+from app.services.notifications_common import (
+    customer_contact_url,
+    followup_url,
+    resolve_business_phone,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _order_followup_url(phone: str, order_number: str) -> str:
+    """wa.me link a customer can use to follow up on their order."""
+    message = (
+        "Hi Glam by Lynn — I'd like to follow up on my order.\n"
+        f"Order number: {order_number}"
+    )
+    return followup_url(phone, message)
+
+
+def schedule_order_notifications(
+    db: Session,
+    order: Order,
+    items_data: List[dict],
+    user: Optional[User],
+    guest_info: Optional[GuestInfo],
+    delivery_info: DeliveryInfo,
+    background_tasks: BackgroundTasks,
+) -> None:
+    """Queue customer + admin emails for a freshly created order.
+
+    Resolves all data up front (relationships, settings) so the background
+    tasks receive plain values and don't touch the request-scoped session.
+    """
+    # Customer contact — guest fields take precedence, fall back to the
+    # registered user's profile. Phone is stored on the order for both.
+    customer_email = (
+        guest_info.email if guest_info else None
+    ) or (user.email if user else None)
+    customer_name = (
+        (guest_info.name if guest_info else None)
+        or (user.full_name if user else None)
+        or (user.email if user else None)
+        or "there"
+    )
+    customer_phone = (
+        order.guest_phone
+        or (guest_info.phone if guest_info else None)
+        or (user.phone_number if user else None)
+        or ""
+    )
+
+    delivery_address = {
+        "address": delivery_info.address,
+        "city": delivery_info.town,
+        "county": delivery_info.county,
+    }
+
+    phone = resolve_business_phone(db)
+    order_followup = (
+        _order_followup_url(phone, order.order_number) if phone else None
+    )
+    customer_wa_url = (
+        customer_contact_url(
+            customer_phone, customer_name, f"order {order.order_number}"
+        )
+        if customer_phone
+        else None
+    )
+    admin_url = f"{settings.FRONTEND_URL.rstrip('/')}/admin/orders"
+
+    subtotal = Decimal(order.subtotal or 0)
+    discount = Decimal(order.discount_amount or 0)
+    delivery_fee = Decimal(order.delivery_fee or 0)
+    total = Decimal(order.total_amount or 0)
+
+    # Customer notification
+    if customer_email:
+        logger.info(
+            "Queuing customer order email for %s (order=%s)",
+            customer_email, order.order_number,
+        )
+        background_tasks.add_task(
+            email_service.send_order_confirmation,
+            to_email=customer_email,
+            order_number=order.order_number,
+            customer_name=customer_name,
+            order_items=items_data,
+            subtotal=subtotal,
+            discount=discount,
+            delivery_fee=delivery_fee,
+            total=total,
+            delivery_address={**delivery_address, "full_name": customer_name, "phone": customer_phone},
+            whatsapp_url=order_followup,
+            call_number=phone,
+        )
+    else:
+        logger.warning(
+            "No customer email for order %s — skipping customer notification",
+            order.order_number,
+        )
+
+    # Admin notification(s)
+    admin_recipients: List[str] = list(settings.ADMIN_EMAILS or [])
+    for admin_email in admin_recipients:
+        background_tasks.add_task(
+            email_service.send_order_admin_notification,
+            to_email=admin_email,
+            order_number=order.order_number,
+            customer_name=customer_name,
+            customer_email=customer_email or "Not provided",
+            customer_phone=customer_phone or "Not provided",
+            order_items=items_data,
+            subtotal=subtotal,
+            discount=discount,
+            delivery_fee=delivery_fee,
+            total=total,
+            delivery_address=delivery_address,
+            admin_url=admin_url,
+            customer_whatsapp_url=customer_wa_url,
+        )

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import List, Optional, Tuple
 from uuid import UUID
 
+from fastapi import BackgroundTasks
 from sqlalchemy.orm import Session
 
 from app.models.order import Cart, CartItem, Order, OrderItem
@@ -15,6 +16,7 @@ from app.models.user import User
 from app.schemas.order import DeliveryInfo, GuestInfo, OrderItemCreate
 from app.services import promo_code_service
 from app.services.email_service import email_service
+from app.services.order_notifications import schedule_order_notifications
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +215,8 @@ def create_order(
     promo_code: Optional[str],
     payment_method: Optional[str],
     cart_items: Optional[List[OrderItemCreate]] = None,
+    contact_phone: Optional[str] = None,
+    background_tasks: Optional[BackgroundTasks] = None,
 ) -> Tuple[bool, str, Optional[Order]]:
     """
     Create a new order from the user's bag.
@@ -230,6 +234,12 @@ def create_order(
         promo_code: Optional promo code
         payment_method: Payment method chosen
         cart_items: Inline items for guest checkout
+        contact_phone: Phone for authenticated checkout (accounts have no phone
+            field); stored on the order so we can reach the customer. Ignored
+            for guests, whose phone comes from guest_info.
+        background_tasks: FastAPI background tasks used to send the customer +
+            admin emails without blocking (or failing) the order. If omitted,
+            the customer email is sent synchronously as a fallback.
 
     Returns:
         Tuple of (success, message, order)
@@ -289,7 +299,10 @@ def create_order(
         user_id=user.id if user else None,
         guest_email=guest_info.email if guest_info else None,
         guest_name=guest_info.name if guest_info else None,
-        guest_phone=guest_info.phone if guest_info else None,
+        # Phone always lands in guest_phone: from guest_info for guests, from
+        # the checkout's contact field for signed-in users (accounts store no
+        # phone). It's how we reach the customer about the order.
+        guest_phone=(guest_info.phone if guest_info else contact_phone) or None,
         delivery_county=delivery_info.county,
         delivery_town=delivery_info.town,
         delivery_address=delivery_info.address,
@@ -345,16 +358,29 @@ def create_order(
     db.commit()
     db.refresh(order)
 
-    # Send order confirmation email. Failures are logged but do not fail the
-    # order — the order has already been persisted and the user has seen the
-    # confirmation page.
-    _send_order_confirmation_email(
-        order=order,
-        items_data=items_data,
-        user=user,
-        guest_info=guest_info,
-        delivery_info=delivery_info,
-    )
+    # Notify the customer and admin. Sends run on background tasks so a slow or
+    # failing mail provider never blocks (or fails) the order — it's already
+    # persisted and the user has seen the confirmation page. When no
+    # background_tasks is supplied (e.g. non-route callers), fall back to a
+    # synchronous customer email.
+    if background_tasks is not None:
+        schedule_order_notifications(
+            db=db,
+            order=order,
+            items_data=items_data,
+            user=user,
+            guest_info=guest_info,
+            delivery_info=delivery_info,
+            background_tasks=background_tasks,
+        )
+    else:
+        _send_order_confirmation_email(
+            order=order,
+            items_data=items_data,
+            user=user,
+            guest_info=guest_info,
+            delivery_info=delivery_info,
+        )
 
     return True, "Order created successfully", order
 

--- a/backend/app/services/site_settings_service.py
+++ b/backend/app/services/site_settings_service.py
@@ -35,6 +35,17 @@ def get_public_settings(db: Session) -> Dict[str, Any]:
         "social_twitter",
         "social_tiktok",
         "social_youtube",
+        # Payment / contact details shown on the order confirmation page.
+        # These are meant to be public (customers need them to pay and reach us)
+        # — unlike whatsapp_phone_number, which stays server-side.
+        "payment_mpesa_paybill",
+        "payment_bank_name",
+        "payment_bank_account_name",
+        "payment_bank_account_number",
+        "payment_confirmation_phone",
+        "payment_confirmation_email",
+        "contact_phone",
+        "contact_email",
     ]
     all_settings = get_all_settings(db)
     return {k: v for k, v in all_settings.items() if k in PUBLIC_KEYS}

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -90,12 +90,16 @@ export default function AdminSettingsPage() {
     sunday: { open: "09:00", close: "18:00", closed: true },
   });
 
-  // Payment Settings
+  // Payment Settings (shown to customers on the order confirmation page)
   const [paymentSettings, setPaymentSettings] = useState({
-    mpesaEnabled: true,
-    mpesaShortcode: "",
-    depositPercentage: 50,
-    acceptCash: true,
+    mpesaPaybill: "",
+    bankName: "",
+    bankAccountName: "",
+    bankAccountNumber: "",
+    confirmationPhone: "",
+    confirmationEmail: "",
+    contactPhone: "",
+    contactEmail: "",
   });
 
   // Notification Settings
@@ -165,6 +169,17 @@ export default function AdminSettingsPage() {
             youtube: data.social_youtube ?? "",
           }));
           setWhatsappPhone(data.whatsapp_phone_number ?? "");
+          setPaymentSettings((prev) => ({
+            ...prev,
+            mpesaPaybill: data.payment_mpesa_paybill ?? "",
+            bankName: data.payment_bank_name ?? "",
+            bankAccountName: data.payment_bank_account_name ?? "",
+            bankAccountNumber: data.payment_bank_account_number ?? "",
+            confirmationPhone: data.payment_confirmation_phone ?? "",
+            confirmationEmail: data.payment_confirmation_email ?? "",
+            contactPhone: data.contact_phone ?? "",
+            contactEmail: data.contact_email ?? "",
+          }));
         }
 
         // Load Instagram settings
@@ -370,8 +385,31 @@ export default function AdminSettingsPage() {
     setSaveSuccess("");
 
     try {
-      // TODO: Implement API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      const token = (session as any)?.accessToken;
+      const response = await fetch(
+        `${API_BASE_URL}${API_ENDPOINTS.SETTINGS.ADMIN_UPDATE}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            payment_mpesa_paybill: paymentSettings.mpesaPaybill.trim(),
+            payment_bank_name: paymentSettings.bankName.trim(),
+            payment_bank_account_name: paymentSettings.bankAccountName.trim(),
+            payment_bank_account_number: paymentSettings.bankAccountNumber.trim(),
+            payment_confirmation_phone: paymentSettings.confirmationPhone.trim(),
+            payment_confirmation_email: paymentSettings.confirmationEmail.trim(),
+            contact_phone: paymentSettings.contactPhone.trim(),
+            contact_email: paymentSettings.contactEmail.trim(),
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to save payment settings");
+      }
 
       setSaveSuccess("Payment settings saved successfully");
       setTimeout(() => setSaveSuccess(""), 3000);
@@ -1200,62 +1238,113 @@ export default function AdminSettingsPage() {
         {/* Payment Settings Section */}
         <Card>
           <CardHeader>
-            <CardTitle>Payment Settings</CardTitle>
+            <CardTitle>Payment & Contact Details</CardTitle>
             <CardDescription>
-              Configure payment methods and deposit requirements
+              Shown to customers on the order confirmation page. Leave a field
+              blank to hide it.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <div className="flex items-center justify-between p-4 border rounded-lg">
-              <div>
-                <div className="font-medium">M-Pesa Payments</div>
-                <div className="text-sm text-muted-foreground">Accept M-Pesa payments</div>
-              </div>
-              <Switch
-                checked={paymentSettings.mpesaEnabled}
-                onCheckedChange={(checked) => setPaymentSettings({ ...paymentSettings, mpesaEnabled: checked })}
-              />
-            </div>
-
-            {paymentSettings.mpesaEnabled && (
-              <div className="space-y-2">
-                <Label htmlFor="mpesa-shortcode">M-Pesa Shortcode</Label>
-                <Input
-                  id="mpesa-shortcode"
-                  value={paymentSettings.mpesaShortcode}
-                  onChange={(e) => setPaymentSettings({ ...paymentSettings, mpesaShortcode: e.target.value })}
-                  placeholder="Enter M-Pesa shortcode"
-                />
-              </div>
-            )}
-
-            <div className="flex items-center justify-between p-4 border rounded-lg">
-              <div>
-                <div className="font-medium">Cash Payments</div>
-                <div className="text-sm text-muted-foreground">Accept cash on delivery/service</div>
-              </div>
-              <Switch
-                checked={paymentSettings.acceptCash}
-                onCheckedChange={(checked) => setPaymentSettings({ ...paymentSettings, acceptCash: checked })}
-              />
-            </div>
-
             <div className="space-y-2">
-              <Label>Deposit Percentage</Label>
-              <div className="flex items-center gap-4">
-                <input
-                  type="range"
-                  min="0"
-                  max="100"
-                  value={paymentSettings.depositPercentage}
-                  onChange={(e) => setPaymentSettings({ ...paymentSettings, depositPercentage: parseInt(e.target.value) })}
-                  className="flex-1"
-                />
-                <span className="font-medium w-12 text-right">{paymentSettings.depositPercentage}%</span>
-              </div>
+              <Label htmlFor="mpesa-paybill">M-Pesa Paybill / Business Number</Label>
+              <Input
+                id="mpesa-paybill"
+                value={paymentSettings.mpesaPaybill}
+                onChange={(e) => setPaymentSettings({ ...paymentSettings, mpesaPaybill: e.target.value })}
+                placeholder="e.g. 247247"
+              />
               <p className="text-sm text-muted-foreground">
-                Required deposit for bookings
+                Customers use their order number as the account number.
               </p>
+            </div>
+
+            <div className="space-y-4 rounded-lg border p-4">
+              <div className="font-medium">Bank Transfer</div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="bank-name">Bank Name</Label>
+                  <Input
+                    id="bank-name"
+                    value={paymentSettings.bankName}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, bankName: e.target.value })}
+                    placeholder="e.g. Equity Bank"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="bank-account-name">Account Name</Label>
+                  <Input
+                    id="bank-account-name"
+                    value={paymentSettings.bankAccountName}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, bankAccountName: e.target.value })}
+                    placeholder="e.g. Glam by Lynn"
+                  />
+                </div>
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="bank-account-number">Account Number</Label>
+                  <Input
+                    id="bank-account-number"
+                    value={paymentSettings.bankAccountNumber}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, bankAccountNumber: e.target.value })}
+                    placeholder="Bank account number"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 rounded-lg border p-4">
+              <div className="font-medium">Payment Confirmation</div>
+              <p className="text-sm text-muted-foreground">
+                Where customers send proof of payment.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="confirmation-phone">WhatsApp / Phone</Label>
+                  <Input
+                    id="confirmation-phone"
+                    value={paymentSettings.confirmationPhone}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, confirmationPhone: e.target.value })}
+                    placeholder="+254 7XX XXX XXX"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="confirmation-email">Email</Label>
+                  <Input
+                    id="confirmation-email"
+                    type="email"
+                    value={paymentSettings.confirmationEmail}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, confirmationEmail: e.target.value })}
+                    placeholder="payments@example.com"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 rounded-lg border p-4">
+              <div className="font-medium">Customer Support Contact</div>
+              <p className="text-sm text-muted-foreground">
+                Shown under &quot;Need Help?&quot; on the confirmation page.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="contact-phone">Phone / WhatsApp</Label>
+                  <Input
+                    id="contact-phone"
+                    value={paymentSettings.contactPhone}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, contactPhone: e.target.value })}
+                    placeholder="+254 7XX XXX XXX"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="contact-email">Email</Label>
+                  <Input
+                    id="contact-email"
+                    type="email"
+                    value={paymentSettings.contactEmail}
+                    onChange={(e) => setPaymentSettings({ ...paymentSettings, contactEmail: e.target.value })}
+                    placeholder="info@example.com"
+                  />
+                </div>
+              </div>
             </div>
 
             <div className="flex justify-end">

--- a/frontend/src/app/bookings/new/page.tsx
+++ b/frontend/src/app/bookings/new/page.tsx
@@ -25,6 +25,7 @@ import {
   formatDate,
 } from "@/lib/bookings";
 import { LocationAutocomplete } from "@/components/LocationAutocomplete";
+import { isValidEmail, isValidPhone, normalizePhone } from "@/lib/contact";
 import { useAuth } from "@/hooks/useAuth";
 import {
   Loader2,
@@ -62,17 +63,8 @@ function BookingFormContent() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // --- Contact validation -------------------------------------------------
-  // Loose enough to accept anything that's recognisably an email — a
-  // single @ with a TLD-looking right-hand side. We're after "is this
-  // address typo-free enough to reach the user", not RFC compliance.
-  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-  // Kenyan mobile: +254 7XX/1XX XXX XXX, or 07XX/01XX XXX XXX. Strip
-  // spaces/dashes before checking.
-  const PHONE_RE = /^(?:\+?254|0)(?:7|1)\d{8}$/;
-  const normalizePhone = (s: string) => s.replace(/[\s-]/g, "");
-  const isValidEmail = (s: string) => EMAIL_RE.test(s.trim());
-  const isValidPhone = (s: string) => PHONE_RE.test(normalizePhone(s));
+  // Contact validation (KE phone / email) lives in lib/contact so the
+  // checkout flow shares the exact same rules.
 
   // Form state
   const [selectedPackageId, setSelectedPackageId] = useState<string>("");

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useAuth } from "@/hooks/useAuth";
 import { useCart } from "@/hooks/useCart";
+import { isValidEmail, isValidPhone, normalizePhone } from "@/lib/contact";
 import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
 import { ShoppingBag, MapPin, Plus, Check, AlertCircle, Loader2 } from "lucide-react";
 import Image from "next/image";
@@ -163,6 +164,16 @@ export default function CheckoutPage() {
       return;
     }
 
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address");
+      return;
+    }
+
+    if (!isValidPhone(phone)) {
+      setError("Please enter a valid Kenyan mobile number, e.g. 0712 345 678");
+      return;
+    }
+
     if (!termsAccepted) {
       setError("Please accept the terms and conditions to proceed");
       return;
@@ -201,6 +212,10 @@ export default function CheckoutPage() {
           address: finalAddress,
         },
         promoCode: promoCode || undefined,
+        // Accounts store no phone, so always send the contact phone — it's how
+        // we reach the customer about the order (used for auth checkout; guests
+        // also carry it in guestInfo below).
+        contactPhone: normalizePhone(phone),
       };
 
       // For guest checkout, send guest contact details and inline cart items
@@ -209,7 +224,7 @@ export default function CheckoutPage() {
         orderData.guestInfo = {
           name: fullName,
           email: email,
-          phone: phone,
+          phone: normalizePhone(phone),
         };
         orderData.cartItems = cartItems.map((item) => ({
           productId: item.productId,
@@ -356,7 +371,13 @@ export default function CheckoutPage() {
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       required
+                      aria-invalid={email.length > 0 && !isValidEmail(email)}
                     />
+                    {email.length > 0 && !isValidEmail(email) && (
+                      <p className="text-xs text-destructive">
+                        Enter a valid email address (e.g. you@example.com).
+                      </p>
+                    )}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="phone">Phone Number</Label>
@@ -366,8 +387,20 @@ export default function CheckoutPage() {
                       value={phone}
                       onChange={(e) => setPhone(e.target.value)}
                       required
-                      placeholder="+254..."
+                      placeholder="+254 7XX XXX XXX"
+                      aria-invalid={phone.length > 0 && !isValidPhone(phone)}
                     />
+                    {phone.length > 0 && !isValidPhone(phone) ? (
+                      <p className="text-xs text-destructive">
+                        Enter a Kenyan mobile number, e.g. +254 712 345 678 or
+                        0712 345 678.
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        We&apos;ll use this to confirm your order and reach you on
+                        WhatsApp or by call.
+                      </p>
+                    )}
                   </div>
                 </CardContent>
               </Card>
@@ -599,7 +632,14 @@ export default function CheckoutPage() {
                     type="submit"
                     className="w-full"
                     size="lg"
-                    disabled={submitting || success || !termsAccepted}
+                    disabled={
+                      submitting ||
+                      success ||
+                      !termsAccepted ||
+                      !fullName.trim() ||
+                      !isValidEmail(email) ||
+                      !isValidPhone(phone)
+                    }
                   >
                     {submitting ? (
                       <>

--- a/frontend/src/app/orders/[id]/confirmation/page.tsx
+++ b/frontend/src/app/orders/[id]/confirmation/page.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Order } from "@/types";
 import { getOrderById, formatCurrency, formatDateTime, formatStatus, getStatusBadgeVariant } from "@/lib/orders";
 import { useAuth } from "@/hooks/useAuth";
+import { usePublicSettings } from "@/hooks/usePublicSettings";
 import {
   Loader2,
   CheckCircle,
@@ -32,7 +33,19 @@ export default function OrderConfirmationPage() {
   const router = useRouter();
   const params = useParams();
   const { session, authenticated } = useAuth();
+  const { settings } = usePublicSettings();
   const orderId = params?.id as string;
+
+  // Admin-configurable payment / contact details (see SiteSettings PUBLIC_KEYS).
+  const mpesaPaybill = settings.payment_mpesa_paybill as string | undefined;
+  const bankName = settings.payment_bank_name as string | undefined;
+  const bankAccountName = settings.payment_bank_account_name as string | undefined;
+  const bankAccountNumber = settings.payment_bank_account_number as string | undefined;
+  const paymentPhone = settings.payment_confirmation_phone as string | undefined;
+  const paymentEmail = settings.payment_confirmation_email as string | undefined;
+  const contactPhone = settings.contact_phone as string | undefined;
+  const contactEmail = settings.contact_email as string | undefined;
+  const hasBankDetails = Boolean(bankName && bankAccountNumber);
 
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
@@ -280,72 +293,97 @@ export default function OrderConfirmationPage() {
                 <CardDescription>Complete your payment to process your order</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="rounded-lg bg-muted p-4">
-                  <h4 className="mb-2 font-semibold">M-Pesa Payment</h4>
-                  <ol className="space-y-2 text-sm">
-                    <li className="flex gap-2">
-                      <span className="font-semibold">1.</span>
-                      <span>Go to M-Pesa on your phone</span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">2.</span>
-                      <span>Select Lipa Na M-Pesa, then Pay Bill</span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">3.</span>
-                      <span>
-                        Enter Business Number: <strong>123456</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">4.</span>
-                      <span>
-                        Enter Account Number: <strong>{order.orderNumber}</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">5.</span>
-                      <span>
-                        Enter Amount: <strong>{formatCurrency(order.totalAmount)}</strong>
-                      </span>
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="font-semibold">6.</span>
-                      <span>Enter your M-Pesa PIN and confirm</span>
-                    </li>
-                  </ol>
-                </div>
+                {mpesaPaybill && (
+                  <div className="rounded-lg bg-muted p-4">
+                    <h4 className="mb-2 font-semibold">M-Pesa Payment</h4>
+                    <ol className="space-y-2 text-sm">
+                      <li className="flex gap-2">
+                        <span className="font-semibold">1.</span>
+                        <span>Go to M-Pesa on your phone</span>
+                      </li>
+                      <li className="flex gap-2">
+                        <span className="font-semibold">2.</span>
+                        <span>Select Lipa Na M-Pesa, then Pay Bill</span>
+                      </li>
+                      <li className="flex gap-2">
+                        <span className="font-semibold">3.</span>
+                        <span>
+                          Enter Business Number: <strong>{mpesaPaybill}</strong>
+                        </span>
+                      </li>
+                      <li className="flex gap-2">
+                        <span className="font-semibold">4.</span>
+                        <span>
+                          Enter Account Number: <strong>{order.orderNumber}</strong>
+                        </span>
+                      </li>
+                      <li className="flex gap-2">
+                        <span className="font-semibold">5.</span>
+                        <span>
+                          Enter Amount: <strong>{formatCurrency(order.totalAmount)}</strong>
+                        </span>
+                      </li>
+                      <li className="flex gap-2">
+                        <span className="font-semibold">6.</span>
+                        <span>Enter your M-Pesa PIN and confirm</span>
+                      </li>
+                    </ol>
+                  </div>
+                )}
 
-                <div className="rounded-lg border border-border p-4">
-                  <h4 className="mb-2 font-semibold">Bank Transfer</h4>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Bank:</span>
-                      <span className="font-medium">Equity Bank</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Account Name:</span>
-                      <span className="font-medium">Glam by Lynn</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Account Number:</span>
-                      <span className="font-medium">1234567890</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Reference:</span>
-                      <span className="font-medium">{order.orderNumber}</span>
+                {hasBankDetails && (
+                  <div className="rounded-lg border border-border p-4">
+                    <h4 className="mb-2 font-semibold">Bank Transfer</h4>
+                    <div className="space-y-2 text-sm">
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Bank:</span>
+                        <span className="font-medium">{bankName}</span>
+                      </div>
+                      {bankAccountName && (
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Account Name:</span>
+                          <span className="font-medium">{bankAccountName}</span>
+                        </div>
+                      )}
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Account Number:</span>
+                        <span className="font-medium">{bankAccountNumber}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Reference:</span>
+                        <span className="font-medium">{order.orderNumber}</span>
+                      </div>
                     </div>
                   </div>
-                </div>
+                )}
 
-                <div className="flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm dark:bg-blue-950/20">
-                  <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
-                  <p className="text-blue-900 dark:text-blue-100">
-                    After making payment, send confirmation via WhatsApp to{" "}
-                    <strong>+254 700 000 000</strong> or email to{" "}
-                    <strong>payments@glambylynn.com</strong>
-                  </p>
-                </div>
+                {!mpesaPaybill && !hasBankDetails && (
+                  <div className="rounded-lg bg-muted p-4 text-sm text-muted-foreground">
+                    Our team will contact you shortly with payment instructions for
+                    order <strong>{order.orderNumber}</strong>.
+                  </div>
+                )}
+
+                {(paymentPhone || paymentEmail) && (
+                  <div className="flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm dark:bg-blue-950/20">
+                    <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+                    <p className="text-blue-900 dark:text-blue-100">
+                      After making payment, send confirmation
+                      {paymentPhone && (
+                        <>
+                          {" "}via WhatsApp to <strong>{paymentPhone}</strong>
+                        </>
+                      )}
+                      {paymentPhone && paymentEmail && " or"}
+                      {paymentEmail && (
+                        <>
+                          {" "}email to <strong>{paymentEmail}</strong>
+                        </>
+                      )}
+                      .
+                    </p>
+                  </div>
+                )}
               </CardContent>
             </Card>
           )}
@@ -414,27 +452,34 @@ export default function OrderConfirmationPage() {
               <CardDescription>Get in touch with us</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <div className="flex items-center gap-3">
-                <Phone className="h-5 w-5 text-muted-foreground" />
-                <div>
-                  <p className="text-sm text-muted-foreground">Phone / WhatsApp</p>
-                  <a href="tel:+254700000000" className="font-medium hover:text-secondary">
-                    +254 700 000 000
-                  </a>
+              {contactPhone && (
+                <div className="flex items-center gap-3">
+                  <Phone className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Phone / WhatsApp</p>
+                    <a
+                      href={`tel:${contactPhone.replace(/\s/g, "")}`}
+                      className="font-medium hover:text-secondary"
+                    >
+                      {contactPhone}
+                    </a>
+                  </div>
                 </div>
-              </div>
-              <div className="flex items-center gap-3">
-                <Mail className="h-5 w-5 text-muted-foreground" />
-                <div>
-                  <p className="text-sm text-muted-foreground">Email</p>
-                  <a
-                    href="mailto:info@glambylynn.com"
-                    className="font-medium hover:text-secondary"
-                  >
-                    info@glambylynn.com
-                  </a>
+              )}
+              {contactEmail && (
+                <div className="flex items-center gap-3">
+                  <Mail className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Email</p>
+                    <a
+                      href={`mailto:${contactEmail}`}
+                      className="font-medium hover:text-secondary"
+                    >
+                      {contactEmail}
+                    </a>
+                  </div>
                 </div>
-              </div>
+              )}
               <div className="mt-4 rounded-lg bg-muted p-3 text-sm">
                 <p className="text-muted-foreground">
                   Order placed on {formatDateTime(order.createdAt || new Date().toISOString())}

--- a/frontend/src/lib/contact.ts
+++ b/frontend/src/lib/contact.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared contact-field validation for the booking and checkout flows.
+ *
+ * Loose enough on email to accept anything recognisably an address (a single @
+ * with a TLD-looking right-hand side) — we're after "typo-free enough to reach
+ * the customer", not RFC compliance. Phone targets Kenyan mobiles.
+ */
+
+// Single @ with a dotted, 2+ char TLD on the right.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+// Kenyan mobile: +254 7XX/1XX XXX XXX, or 07XX/01XX XXX XXX.
+const PHONE_RE = /^(?:\+?254|0)(?:7|1)\d{8}$/;
+
+/** Strip spaces/dashes so formatted input still validates. */
+export const normalizePhone = (s: string): string => s.replace(/[\s-]/g, "");
+
+export const isValidEmail = (s: string): boolean => EMAIL_RE.test(s.trim());
+
+export const isValidPhone = (s: string): boolean =>
+  PHONE_RE.test(normalizePhone(s));


### PR DESCRIPTION
## Summary

Streamlines the **product checkout** to match the **service-booking** flow where they overlap — contact details, order confirmation, and email alerts — to reduce cart abandonment. Closes the gaps found while reviewing both flows side by side.

## Contact details
- New `frontend/src/lib/contact.ts` with shared KE phone/email validators; booking and checkout now use the same rules (booking refactored, behavior identical).
- Checkout validates + normalizes the phone, shows inline errors, and disables **Place Order** until name/email/phone are valid (previously non-empty only, no phone validation).
- **Phone is now captured for authenticated orders** — auth checkout was silently dropping the phone, so signed-in orders stored none and emails couldn't reach the buyer. New optional `contactPhone` on `OrderCreate` → persisted to the existing `orders.guest_phone` column (no migration).

## Email alerts (parity with bookings)
- Orders now send an **admin notification** (`send_order_admin_notification`) with Call / WhatsApp-customer / open-in-dashboard buttons to each `ADMIN_EMAILS`.
- Customer order email gains **Follow up on WhatsApp** / **Call us** buttons.
- Order emails send via **`BackgroundTasks`** (non-blocking) with **hardened logging**, replacing the synchronous swallow-and-warn.
- Shared phone/`wa.me` helpers extracted into `notifications_common.py` so booking + order flows share one copy.

## Payment details → admin-configurable
- The confirmation page's hardcoded placeholders (`123456`, `1234567890`, `+254 700 000 000`, `payments@glambylynn.com`) are replaced by admin-configured SiteSettings, read via `usePublicSettings` with graceful hiding when unset.
- New public SiteSettings keys added to `PUBLIC_KEYS`; the admin **Payment & Contact Details** section now actually persists (the previous handler was a `setTimeout` TODO).

## Verification
- Backend modules import cleanly; new order emails render in console provider mode.
- Frontend `type-check` passes; no new lint errors (the 7 reported are pre-existing).
- The 8 backend fixture errors are pre-existing/environmental — the test DB is SQLite, which can't build the Postgres ARRAY/JSONB schema.

## Notes / follow-ups
- **Editable name/email for signed-in users**: fields stay editable per spec, but the order *record* for a signed-in user still uses the account name/email (only phone is newly persisted). Honoring typed name/email for signed-in users is a small follow-up if desired.
- **Post-merge config**: set Payment & Contact Details in Admin → Settings, ensure `ADMIN_EMAILS` is set, and redeploy the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)