### PR TITLE
feat(vision): reposition vision section around makeup, beauty & spa wellness

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -17,6 +17,17 @@ const nextConfig: NextConfig = {
   compress: true,
   // Enable React strict mode for better development practices
   reactStrictMode: true,
+  // The vision section moved from /vision-2026 to /vision — keep old links and
+  // search-engine results working.
+  async redirects() {
+    return [
+      {
+        source: "/vision-2026",
+        destination: "/vision",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -35,7 +35,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
-      url: `${baseUrl}/vision-2026`,
+      url: `${baseUrl}/vision`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,

--- a/frontend/src/app/vision/page.tsx
+++ b/frontend/src/app/vision/page.tsx
@@ -12,7 +12,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import {
   Sparkles,
-  Scissors,
   Droplets,
   Truck,
   CheckCircle2,
@@ -28,7 +27,7 @@ import {
 } from "lucide-react";
 import { API_BASE_URL } from "@/config/api";
 
-export default function Vision2026Page() {
+export default function VisionPage() {
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -70,29 +69,18 @@ export default function Vision2026Page() {
   const services = [
     {
       icon: Sparkles,
-      title: "Full-Service Salon",
-      description: "Comprehensive hair care, styling, and treatments in a luxurious setting",
+      title: "Full Beauty Services",
+      description: "A complete range of makeup and beauty treatments under one roof",
       features: [
-        "Professional hair cutting and styling",
-        "Color treatments and highlights",
-        "Hair treatments and conditioning",
-        "Blowouts and special occasion styling",
-        "Bridal and event packages",
+        "Makeup",
+        "Makeup training",
+        "Facials",
+        "Lash extensions",
+        "Microblading",
+        "Deep tissue massages",
+        "Waxing",
       ],
-      image: "/placeholder-salon.jpg",
-    },
-    {
-      icon: Scissors,
-      title: "Modern Barbershop",
-      description: "Premium grooming services for the modern gentleman",
-      features: [
-        "Classic and contemporary haircuts",
-        "Hot towel shaves and beard grooming",
-        "Hair and scalp treatments",
-        "Grooming consultations",
-        "Membership packages available",
-      ],
-      image: "/placeholder-barber.jpg",
+      image: "/placeholder-beauty.jpg",
     },
     {
       icon: Droplets,
@@ -103,22 +91,22 @@ export default function Vision2026Page() {
         "Body massages and therapies",
         "Manicures and pedicures",
         "Waxing and threading services",
-        "Couples spa packages",
+        "Trusted authentic makeup products",
       ],
       image: "/placeholder-spa.jpg",
     },
     {
       icon: Truck,
-      title: "Mobile Beauty Van",
+      title: "Mobile Beauty",
       description: "Bringing premium beauty services directly to you",
       features: [
         "On-location makeup services",
-        "Mobile hair styling",
+        "Beauty products delivery",
         "Event and wedding services",
         "Corporate wellness programs",
         "Serving Kitui and Nairobi regions",
       ],
-      image: "/placeholder-van.jpg",
+      image: "/placeholder-mobile.jpg",
     },
   ];
 
@@ -166,16 +154,16 @@ export default function Vision2026Page() {
         <div className="container relative mx-auto px-4">
           <div className="mx-auto max-w-4xl text-center">
             <Badge className="mb-6 text-base bg-vision-gradient text-white border-0 shadow-lg shadow-pink-500/30">
-              Coming 2026
+              Coming Soon
             </Badge>
             <h1 className="mb-6 text-4xl font-bold tracking-tight md:text-6xl drop-shadow-lg">
               Our <span className="text-[#FFB6C1]">Vision</span> for Tomorrow
             </h1>
             <p className="mb-8 text-lg text-white/80 md:text-xl">
               Building on our foundation of excellence in makeup artistry and beauty products,
-              we're expanding to offer a complete beauty and wellness destination. From premium salon
-              services to rejuvenating spa treatments, we're bringing world-class experiences to
-              Kitui and Nairobi.
+              we're expanding into a complete beauty and wellness destination. From full beauty
+              services to rejuvenating spa treatments and trusted authentic makeup products, we're
+              bringing world-class experiences to Kitui and Nairobi.
             </p>
             <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
               <Button size="lg" asChild className="bg-pink-gradient hover:opacity-90 text-white border-0 shadow-lg shadow-pink-500/30">
@@ -207,7 +195,7 @@ export default function Vision2026Page() {
                   A Complete Beauty Ecosystem
                 </h2>
                 <p className="mb-6 text-lg text-muted-foreground">
-                  By 2026, Glam by Lynn will be East Africa's premier destination for comprehensive
+                  Glam by Lynn is set to become East Africa's premier destination for comprehensive
                   beauty and wellness services. We're creating spaces where artistry meets technology,
                   tradition meets innovation, and every client experiences transformation.
                 </p>
@@ -225,10 +213,10 @@ export default function Vision2026Page() {
         <div className="container mx-auto px-4">
           <div className="mb-12 text-center">
             <h2 className="mb-4 text-3xl font-bold md:text-4xl">
-              Our <span className="text-secondary">2026</span> Service Offerings
+              Our <span className="text-secondary">Service</span> Offerings
             </h2>
             <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
-              Four distinct service categories designed to meet all your beauty and wellness needs
+              Distinct service categories designed to meet all your beauty and wellness needs
             </p>
           </div>
 
@@ -358,7 +346,7 @@ export default function Vision2026Page() {
                 Be the First to Know
               </h2>
               <p className="text-lg text-muted-foreground">
-                Register your interest and receive exclusive updates on our 2026 launch,
+                Register your interest and receive exclusive updates on our launch,
                 including early bird discounts and special offers.
               </p>
             </div>
@@ -370,7 +358,7 @@ export default function Vision2026Page() {
                   <span className="font-medium">Thank you for your interest!</span>
                 </div>
                 <p className="mt-1 text-sm text-green-700">
-                  We'll keep you updated on our 2026 launch and send you exclusive early access offers.
+                  We'll keep you updated on our launch and send you exclusive early access offers.
                 </p>
               </div>
             )}
@@ -432,7 +420,7 @@ export default function Vision2026Page() {
                       id="serviceInterest"
                       value={formData.serviceInterest}
                       onChange={(e) => setFormData({ ...formData, serviceInterest: e.target.value })}
-                      placeholder="e.g., Salon, Spa, Barbershop, Mobile Services"
+                      placeholder="e.g., Makeup, Beauty, Spa, Mobile Services"
                     />
                   </div>
 
@@ -442,7 +430,7 @@ export default function Vision2026Page() {
                       id="message"
                       value={formData.message}
                       onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-                      placeholder="Tell us what excites you most about our 2026 vision..."
+                      placeholder="Tell us what excites you most about our vision..."
                       rows={4}
                     />
                   </div>
@@ -467,7 +455,7 @@ export default function Vision2026Page() {
                   </Button>
 
                   <p className="text-center text-sm text-muted-foreground">
-                    By submitting, you agree to receive updates about our 2026 launch.
+                    By submitting, you agree to receive updates about our launch.
                     You can unsubscribe at any time.
                   </p>
                 </form>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -171,10 +171,10 @@ export function Header() {
               Gallery
             </Link>
             <Link
-              href="/vision-2026"
-              className={`flex items-center gap-1.5 ${navLinkClass("/vision-2026")}`}
+              href="/vision"
+              className={`flex items-center gap-1.5 ${navLinkClass("/vision")}`}
             >
-              Vision 2026
+              Our Vision
               <Badge className="text-xs bg-vision-gradient text-white border-0">New</Badge>
             </Link>
             {isAdmin && (
@@ -335,11 +335,11 @@ export function Header() {
                     Gallery
                   </Link>
                   <Link
-                    href="/vision-2026"
-                    className={`flex items-center gap-2 ${mobileNavLinkClass("/vision-2026")}`}
+                    href="/vision"
+                    className={`flex items-center gap-2 ${mobileNavLinkClass("/vision")}`}
                     onClick={() => setMobileMenuOpen(false)}
                   >
-                    Vision 2026
+                    Our Vision
                     <Badge variant="secondary" className="text-xs">New</Badge>
                   </Link>
 

--- a/frontend/src/lib/metadata.ts
+++ b/frontend/src/lib/metadata.ts
@@ -8,7 +8,7 @@ import { Metadata } from 'next'
  */
 export const siteConfig = {
   name: 'Glam by Lynn',
-  description: 'Premier makeup artistry and beauty services in Kitui and Nairobi, Kenya. Professional makeup, beauty products, and 2026 vision for comprehensive salon, spa, and barbershop services.',
+  description: 'Premier makeup artistry and beauty services in Kitui and Nairobi, Kenya. Professional makeup, beauty products, and a vision for comprehensive beauty, spa, and wellness services.',
   url: process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://glambylynn.com',
   ogImage: '/og-image.jpg', // Fallback static image
   links: {
@@ -40,9 +40,9 @@ export function constructMetadata({
       'bridal makeup',
       'professional makeup',
       'beauty products',
-      'salon services',
       'spa services',
-      'barbershop Kenya',
+      'beauty and wellness Kenya',
+      'makeup training',
       'mobile beauty services',
     ],
     authors: [


### PR DESCRIPTION
## Summary

Repositions the vision section around **makeup, beauty services, and spa wellness**, removing all "2026" framing and any hair/salon/barbershop language. The business is purely makeup, beauty, and spa wellness.

## Changes

- **Route renamed** `/vision-2026` → `/vision` (permanent redirect added in `next.config.ts`; sitemap, header nav, and metadata updated).
- **Three service cards** (down from four — "Modern Barbershop" removed):
  - **Full Beauty Services** — Makeup, Makeup training, Facials, Lash extensions, Microblading, Deep tissue massages, Waxing.
  - **Wellness Spa** — Facials & skincare, Body massages, Manicures & pedicures, Waxing & threading, **Trusted authentic makeup products**.
  - **Mobile Beauty** — On-location makeup, **Beauty products delivery** (replaces "mobile hair styling"), Event & wedding, Corporate wellness, serving Kitui & Nairobi.
- **Copy de-dated**: hero badge "Coming 2026" → "Coming Soon"; "By 2026, Glam by Lynn will be" → "Glam by Lynn is set to become"; "Our 2026 Service Offerings" → "Our Service Offerings"; form copy and placeholders updated.
- **Header** nav label "Vision 2026" → "Our Vision".
- **Metadata/keywords** dropped salon/barbershop, added beauty & wellness / makeup training.

## Verification

- `npm run type-check` clean (after clearing stale `.next` types).
- No new lint errors.
- No remaining references to `2026`, hair, salon, or barbershop in the vision flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
