### PR TITLE
fix(home): render Shop by Category images via public categories endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.core.middleware import (
 )
 
 # Import routers
-from app.routers import auth, services, bookings, gallery, testimonials, products as public_products, promo_codes as public_promo_codes, reviews as public_reviews, cart, wishlist, vision, classes, site_settings as public_site_settings, whatsapp as whatsapp_router
+from app.routers import auth, services, bookings, gallery, testimonials, products as public_products, promo_codes as public_promo_codes, reviews as public_reviews, cart, wishlist, vision, classes, site_settings as public_site_settings, whatsapp as whatsapp_router, categories as public_categories
 from app.api.routes import brands, categories, products, product_images, product_variants, service_packages, orders, reviews
 from app.api.routes.admin import locations as admin_locations, calendar as admin_calendar, bookings as admin_bookings, gallery as admin_gallery, users as admin_users, testimonials as admin_testimonials, promo_codes as admin_promo_codes, analytics as admin_analytics, vision as admin_vision, activity_logs as admin_activity_logs, booking_analytics, classes as admin_classes, site_settings as admin_site_settings, storage_settings as admin_storage_settings, instagram_settings as admin_instagram_settings
 
@@ -102,6 +102,7 @@ app.include_router(bookings.router, prefix="/api")  # Public bookings API
 app.include_router(gallery.router, prefix="/api")  # Public gallery API
 app.include_router(testimonials.router, prefix="/api")  # Public testimonials API
 app.include_router(public_products.router)  # Public products API
+app.include_router(public_categories.router, prefix="/api")  # Public categories API
 app.include_router(public_promo_codes.router, prefix="/api")  # Public promo codes API
 app.include_router(public_reviews.router, prefix="/api")  # Public reviews API
 app.include_router(cart.router, prefix="/api")  # Shopping cart API

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -1,0 +1,29 @@
+"""Public category API routes."""
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.category import CategoryResponse
+from app.services import category_service
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+@router.get("", response_model=list[CategoryResponse])
+async def list_public_categories(
+    limit: int = Query(20, ge=1, le=100, description="Maximum number of categories to return"),
+    db: Session = Depends(get_db),
+):
+    """
+    Get active categories for public display (e.g. homepage "Shop by Category").
+
+    Returns only active categories, ordered by display order, so the storefront
+    can render category tiles with their images without requiring admin auth.
+    """
+    categories, _ = category_service.get_categories(
+        db=db,
+        skip=0,
+        limit=limit,
+        is_active=True,
+    )
+    return categories

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -120,7 +120,7 @@ export default function Home() {
         const categoriesRes = await fetch(`${API_BASE_URL}${API_ENDPOINTS.CATEGORIES.LIST}?limit=4`);
         if (categoriesRes.ok) {
           const categoriesData = await categoriesRes.json();
-          setCategories(categoriesData);
+          setCategories(Array.isArray(categoriesData) ? categoriesData : categoriesData.items || []);
         }
 
         // Fetch featured testimonials
@@ -693,7 +693,18 @@ export default function Home() {
               </div>
             </FadeInSection>
 
-            {categories.length > 0 ? (
+            {loading ? (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                {[...Array(4)].map((_, i) => (
+                  <Card key={i} className="overflow-hidden">
+                    <div className="aspect-square animate-pulse bg-muted" />
+                    <CardHeader>
+                      <div className="mx-auto h-5 w-24 animate-pulse rounded bg-muted" />
+                    </CardHeader>
+                  </Card>
+                ))}
+              </div>
+            ) : categories.length > 0 ? (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {categories.map((category, index) => (
                   <FadeInSection key={category.id} direction="up" delay={0.2 + (index % 4) * 0.1}>
@@ -705,6 +716,7 @@ export default function Home() {
                             src={resolveImageUrl(category.image_url)}
                             alt={category.name}
                             fill
+                            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                             className="object-cover transition-transform group-hover:scale-105"
                           />
                         ) : (


### PR DESCRIPTION
## Problem

The homepage **Shop by Category** section showed category tiles but no images. Root cause: the homepage fetches `GET /api/categories`, but that route did not exist — categories were only mounted under `/api/admin/categories` (admin-only, `get_current_admin_user`). The `404` left `categories` empty, so the section fell back to a hardcoded, **imageless** placeholder grid.

Two secondary bugs would also have broken it: the admin list returns `{items: [...]}` (not a bare array) and paginates on `page_size`, not the `limit` the homepage sent.

## Fix

**Backend**
- New public router `backend/app/routers/categories.py`: `GET /api/categories` returns active categories (name, slug, `image_url`) ordered by display order, no auth — follows the existing `app/routers/` public convention.
- Registered in `main.py` with `/api` prefix (no conflict with the admin routes).

**Frontend (`frontend/src/app/page.tsx`)**
- Parse the response defensively as an array.
- Added a **skeleton preview** gated on the existing `loading` state so tiles no longer flash the imageless fallback while fetching.
- Added responsive `sizes` to the category `next/image` so Next serves correctly sized WebP/AVIF instead of oversized assets.

## Notes
- Images render only for categories that have `image_url` set in admin; otherwise the existing sparkle fallback shows (correct behavior).
- The frontend change depends on the new backend endpoint, so **the backend (EC2/Docker) must be redeployed** for this to take effect in production — Vercel only redeploys the frontend.

## Verification
- `curl localhost:8000/api/categories` → JSON array of active categories with `image_url`.
- Homepage: skeleton shows, then real category tiles with images; clicking routes to `/products?category=<slug>`.
- `npm run type-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)