### PR TITLE
fix(products): edge-to-edge category cards + apply category deep-link filter

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -696,20 +696,22 @@ export default function Home() {
             {loading ? (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {[...Array(4)].map((_, i) => (
-                  <Card key={i} className="overflow-hidden">
-                    <div className="aspect-square animate-pulse bg-muted" />
-                    <CardHeader>
+                  <div key={i} className="overflow-hidden rounded-[2rem] border border-pink-50 bg-white">
+                    <div className="aspect-square animate-pulse bg-pink-50" />
+                    <div className="p-4">
                       <div className="mx-auto h-5 w-24 animate-pulse rounded bg-muted" />
-                    </CardHeader>
-                  </Card>
+                    </div>
+                  </div>
                 ))}
               </div>
             ) : categories.length > 0 ? (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {categories.map((category, index) => (
                   <FadeInSection key={category.id} direction="up" delay={0.2 + (index % 4) * 0.1}>
-                    <Link href={`/products?category=${category.slug}`}>
-                      <Card className="group cursor-pointer overflow-hidden transition-all hover:shadow-lg">
+                    <Link
+                      href={`/products?category=${category.slug}`}
+                      className="group relative flex h-full flex-col overflow-hidden rounded-[2rem] border border-pink-50 bg-white transition-all duration-500 hover:shadow-2xl hover:shadow-pink-100 hover:-translate-y-2"
+                    >
                       <div className="relative aspect-square overflow-hidden bg-gradient-to-br from-secondary/20 to-muted">
                         {category.image_url ? (
                           <Image
@@ -717,23 +719,32 @@ export default function Home() {
                             alt={category.name}
                             fill
                             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-                            className="object-cover transition-transform group-hover:scale-105"
+                            className="object-cover transition-transform duration-700 group-hover:scale-110"
                           />
                         ) : (
                           <div className="flex h-full items-center justify-center">
                             <Sparkles className="h-16 w-16 text-muted-foreground/30" />
                           </div>
                         )}
+                        {/* Pink accent + hover CTA */}
+                        <div className="absolute inset-0 bg-gradient-to-t from-pink-600/30 via-transparent to-transparent opacity-60 transition-opacity duration-300 group-hover:opacity-90" />
+                        <div className="absolute inset-x-0 bottom-0 flex items-center justify-center pb-4 opacity-0 translate-y-3 transition-all duration-300 group-hover:opacity-100 group-hover:translate-y-0">
+                          <span className="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-4 py-1.5 text-xs font-bold text-pink-600 shadow-lg backdrop-blur-sm">
+                            Shop Now
+                            <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
+                          </span>
+                        </div>
                       </div>
-                      <CardHeader>
-                        <CardTitle className="text-center">{category.name}</CardTitle>
+                      <div className="bg-gradient-to-b from-pink-50/40 to-white p-4 text-center">
+                        <h3 className="text-lg font-bold text-[#1a0f1c] transition-colors group-hover:text-pink-600">
+                          {category.name}
+                        </h3>
                         {category.product_count !== undefined && (
-                          <p className="text-center text-sm text-muted-foreground">
+                          <p className="text-sm text-muted-foreground">
                             {category.product_count} products
                           </p>
                         )}
-                      </CardHeader>
-                      </Card>
+                      </div>
                     </Link>
                   </FadeInSection>
                 ))}
@@ -741,12 +752,12 @@ export default function Home() {
             ) : (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {["Makeup", "Skincare", "Tools", "Accessories"].map((name) => (
-                  <Card key={name} className="overflow-hidden">
+                  <div key={name} className="overflow-hidden rounded-[2rem] border border-pink-50 bg-white">
                     <div className="aspect-square bg-gradient-to-br from-secondary/20 to-muted" />
-                    <CardHeader>
-                      <CardTitle className="text-center">{name}</CardTitle>
-                    </CardHeader>
-                  </Card>
+                    <div className="bg-gradient-to-b from-pink-50/40 to-white p-4 text-center">
+                      <h3 className="text-lg font-bold text-[#1a0f1c]">{name}</h3>
+                    </div>
+                  </div>
                 ))}
               </div>
             )}

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -5,8 +5,8 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { Header } from "@/components/Header";
@@ -56,8 +56,9 @@ import { API_BASE_URL, API_ENDPOINTS } from "@/config/api";
 import { resolveImageUrl } from "@/lib/utils";
 import type { Product, Brand, Category } from "@/types";
 
-export default function ProductsPage() {
+function ProductsPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { authenticated, session } = useAuth();
 
   // State
@@ -114,19 +115,12 @@ export default function ProductsPage() {
         setTotalProducts(data.total);
 
         const uniqueBrands = new Map<string, Brand>();
-        const uniqueCategories = new Map<string, Category>();
-
         data.items.forEach((product) => {
           if (product.brand && !uniqueBrands.has(product.brand.id)) {
             uniqueBrands.set(product.brand.id, product.brand);
           }
-          if (product.category && !uniqueCategories.has(product.category.id)) {
-            uniqueCategories.set(product.category.id, product.category);
-          }
         });
-
         setBrands(Array.from(uniqueBrands.values()));
-        setCategories(Array.from(uniqueCategories.values()));
       } catch (error) {
         console.error("Error fetching products:", error);
         setProducts([]);
@@ -137,6 +131,40 @@ export default function ProductsPage() {
 
     fetchProducts();
   }, [filters]);
+
+  // Load all active categories (with slugs) for the filter Select and for
+  // resolving the ?category=<slug> deep link from the homepage category tiles.
+  useEffect(() => {
+    const loadCategories = async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}${API_ENDPOINTS.CATEGORIES.LIST}?limit=100`);
+        if (res.ok) {
+          const data = await res.json();
+          setCategories(Array.isArray(data) ? data : data.items || []);
+        }
+      } catch { /* silently fail — filter Select just stays empty */ }
+    };
+    loadCategories();
+  }, []);
+
+  // Apply the ?category=<slug> deep link once, after categories have loaded, so
+  // the filter is active and the pill/Select reflect it. Guarded so it does not
+  // fight the user if they later clear or change the category filter.
+  const appliedCategoryParam = useRef(false);
+  useEffect(() => {
+    if (appliedCategoryParam.current) return;
+    const slug = searchParams.get("category");
+    if (!slug) {
+      appliedCategoryParam.current = true;
+      return;
+    }
+    if (categories.length === 0) return; // wait for categories to load
+    const match = categories.find((c) => c.slug === slug);
+    if (match) {
+      setFilters((prev) => ({ ...prev, categoryId: match.id, page: 1 }));
+    }
+    appliedCategoryParam.current = true;
+  }, [searchParams, categories]);
 
   // Load wishlist for authenticated users (cart is loaded by useCart)
   useEffect(() => {
@@ -860,5 +888,19 @@ export default function ProductsPage() {
 
       <Footer />
     </div>
+  );
+}
+
+export default function ProductsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-pink-500" />
+        </div>
+      }
+    >
+      <ProductsPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Problems
1. **White space above category images** — homepage "Shop by Category" tiles used shadcn `<Card>`, whose `py-6` top padding pushed the image down.
2. **Filter not applied on click-through** — clicking a tile set `?category=<slug>` in the URL, but the products page never read the param (imported `useRouter`, not `useSearchParams`), and it filters by category **id** while the card passes a **slug**. So the product list didn't filter and no active-filter pill appeared.

## Fix

**Homepage (`frontend/src/app/page.tsx`)**
- Replaced `<Card>` with the same edge-to-edge `Link` card used by **Featured Products**: corner-to-corner `aspect-square` image, `rounded-[2rem] border-pink-50`, `hover:shadow-2xl hover:shadow-pink-100` lift, pink gradient overlay, and a "Shop Now →" hover pill. Skeleton and fallback grids updated to match.

**Products page (`frontend/src/app/products/page.tsx`)**
- Read `?category=<slug>` via `useSearchParams`, resolve to the category `id`, and apply it **once** (ref-guarded so it doesn't fight later user changes) — the existing active-filter pill and `Select` now light up.
- Load categories from the public `/api/categories` endpoint (full list with slugs) instead of deriving them from the current product page.
- Wrapped the page in a `<Suspense>` boundary (required for `useSearchParams` in the App Router).

## Verification
- `npm run type-check` passes.
- `npm run build` passes (exit 0); `/products` still prerenders.
- No new lint issues (flagged errors are all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)