### PR TITLE
feat(services): add showcase image to services with card + detail redesign

### DIFF
--- a/backend/alembic/versions/f7a8b9c0d1e2_add_image_url_to_service_packages.py
+++ b/backend/alembic/versions/f7a8b9c0d1e2_add_image_url_to_service_packages.py
@@ -1,0 +1,29 @@
+"""add image_url to service_packages
+
+Revision ID: f7a8b9c0d1e2
+Revises: e5f6a7b8c9d0
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a8b9c0d1e2"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "service_packages",
+        sa.Column("image_url", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("service_packages", "image_url")

--- a/backend/app/api/routes/service_packages.py
+++ b/backend/app/api/routes/service_packages.py
@@ -2,7 +2,7 @@
 Service Package API routes
 Admin-only endpoints for service package management
 """
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Query, UploadFile, File
 from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import Optional
@@ -197,3 +197,78 @@ async def delete_package(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         )
+
+
+@router.post("/{package_id}/image", response_model=ServicePackageResponse)
+async def upload_package_image(
+    package_id: UUID,
+    file: UploadFile = File(..., description="Showcase image for the service"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user)
+):
+    """
+    Upload (or replace) the showcase image for a service package.
+
+    **Admin only**
+
+    Accepts multipart/form-data with a single image file (max 10MB). The image
+    is stored via the configured storage provider (S3/Cloudinary/local) and its
+    URL is saved on the package. Any previously stored image is removed.
+    """
+    # Validate file type
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid file type. Expected image, got {file.content_type}"
+        )
+
+    # Validate file size (max 10MB)
+    file.file.seek(0, 2)
+    file_size = file.file.tell()
+    file.file.seek(0)
+    if file_size > 10 * 1024 * 1024:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File size exceeds maximum allowed size of 10MB"
+        )
+
+    try:
+        package = service_package_service.upload_package_image(
+            db=db,
+            package_id=package_id,
+            file=file.file,
+            filename=file.filename or "image.jpg",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to upload image: {str(e)}"
+        )
+
+    if not package:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Service package with ID {package_id} not found"
+        )
+
+    return package
+
+
+@router.delete("/{package_id}/image", response_model=ServicePackageResponse)
+async def delete_package_image(
+    package_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user)
+):
+    """
+    Remove the showcase image from a service package.
+
+    **Admin only**
+    """
+    package = service_package_service.delete_package_image(db, package_id)
+    if not package:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Service package with ID {package_id} not found"
+        )
+    return package

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -39,6 +39,7 @@ class ServicePackage(Base):
     min_maids = Column(Integer, default=0)
     includes_facial = Column(Boolean, default=False)
     duration_minutes = Column(Integer)
+    image_url = Column(String(500))
     is_active = Column(Boolean, default=True, index=True)
     display_order = Column(Integer, default=0, index=True)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow)

--- a/backend/app/schemas/service_package.py
+++ b/backend/app/schemas/service_package.py
@@ -24,6 +24,7 @@ class ServicePackageBase(BaseModel):
     min_maids: int = Field(0, ge=0, description="Minimum number of maids")
     includes_facial: bool = Field(False, description="Whether package includes facial")
     duration_minutes: Optional[int] = Field(None, gt=0, description="Service duration in minutes")
+    image_url: Optional[str] = Field(None, max_length=500, description="Service showcase image URL")
     is_active: bool = Field(True, description="Whether package is active")
     display_order: int = Field(0, ge=0, description="Display order (lower = earlier)")
 
@@ -73,6 +74,7 @@ class ServicePackageUpdate(BaseModel):
     min_maids: Optional[int] = Field(None, ge=0)
     includes_facial: Optional[bool] = None
     duration_minutes: Optional[int] = Field(None, gt=0)
+    image_url: Optional[str] = Field(None, max_length=500)
     is_active: Optional[bool] = None
     display_order: Optional[int] = Field(None, ge=0)
 

--- a/backend/app/services/service_package_service.py
+++ b/backend/app/services/service_package_service.py
@@ -2,13 +2,14 @@
 Service Package service
 Business logic for service package management
 """
-from typing import Optional
+from typing import BinaryIO, Optional
 from uuid import UUID
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
 
 from app.models.service import ServicePackage
 from app.schemas.service_package import ServicePackageCreate, ServicePackageUpdate
+from app.services.file_storage_service import file_storage
 
 
 def get_package_by_id(db: Session, package_id: UUID) -> Optional[ServicePackage]:
@@ -242,3 +243,76 @@ def delete_package(db: Session, package_id: UUID) -> bool:
     db.commit()
 
     return True
+
+
+def upload_package_image(
+    db: Session,
+    package_id: UUID,
+    file: BinaryIO,
+    filename: str,
+) -> Optional[ServicePackage]:
+    """
+    Upload (or replace) the showcase image for a service package.
+
+    Uploads the file to storage, saves the resulting URL on the package, and
+    deletes the previously stored image file if one existed.
+
+    Args:
+        db: Database session
+        package_id: Service package ID
+        file: File-like object
+        filename: Original filename
+
+    Returns:
+        Updated service package, or None if the package was not found
+
+    Raises:
+        Exception: If the file upload fails
+    """
+    package = get_package_by_id(db, package_id)
+    if not package:
+        return None
+
+    old_image_url = package.image_url
+
+    image_url = file_storage.upload_file(
+        file=file,
+        filename=filename,
+        folder=f"services/{package_id}",
+    )
+
+    package.image_url = image_url
+    db.commit()
+    db.refresh(package)
+
+    # Best-effort cleanup of the previous image; never block the response on it.
+    if old_image_url and old_image_url != image_url:
+        try:
+            file_storage.delete_file(old_image_url)
+        except Exception:
+            pass
+
+    return package
+
+
+def delete_package_image(db: Session, package_id: UUID) -> Optional[ServicePackage]:
+    """
+    Remove the showcase image from a service package (clears the URL and deletes
+    the stored file). Returns the updated package, or None if not found.
+    """
+    package = get_package_by_id(db, package_id)
+    if not package:
+        return None
+
+    old_image_url = package.image_url
+    package.image_url = None
+    db.commit()
+    db.refresh(package)
+
+    if old_image_url:
+        try:
+            file_storage.delete_file(old_image_url)
+        except Exception:
+            pass
+
+    return package

--- a/frontend/src/app/admin/services/[id]/page.tsx
+++ b/frontend/src/app/admin/services/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ServiceImageUpload } from "@/components/admin/ServiceImageUpload";
 import axios from "axios";
 import { z } from "zod";
 
@@ -82,6 +83,7 @@ export default function EditServicePackage() {
     display_order: 0,
   });
 
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
@@ -122,6 +124,7 @@ export default function EditServicePackage() {
         }
         setDurationValue(bestValue);
         setDurationUnit(bestUnit);
+        setImageUrl(pkg.image_url || null);
 
         setFormData({
           package_type: pkg.package_type || "bridal_large",
@@ -465,6 +468,17 @@ export default function EditServicePackage() {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Showcase Image */}
+        <div className="bg-card border border-border rounded-lg p-6">
+          <h2 className="text-xl font-semibold text-foreground mb-4">Showcase Image</h2>
+          <ServiceImageUpload
+            packageId={packageId}
+            imageUrl={imageUrl}
+            onChange={setImageUrl}
+            disabled={submitting}
+          />
         </div>
 
         {/* Pricing Configuration */}

--- a/frontend/src/app/admin/services/new/page.tsx
+++ b/frontend/src/app/admin/services/new/page.tsx
@@ -326,6 +326,10 @@ export default function NewServicePackage() {
         <div className="bg-card border border-border rounded-lg p-6">
           <h2 className="text-xl font-semibold text-foreground mb-4">Basic Information</h2>
 
+          <div className="mb-4 rounded-md border border-pink-100 bg-pink-50/50 p-3 text-sm text-muted-foreground">
+            💡 Save the service first, then add a <span className="font-medium text-foreground">showcase image</span> from its edit page.
+          </div>
+
           <div className="space-y-4">
             <div className="space-y-2">
               <Label>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -70,6 +70,7 @@ interface ServicePackage {
   min_maids?: number;
   includes_facial: boolean;
   duration_minutes: number;
+  image_url?: string;
   display_order: number;
 }
 
@@ -360,9 +361,21 @@ export default function Home() {
                           router.push(`/services/${service.id}`);
                         }
                       }}
-                      className="group relative flex h-full flex-col overflow-hidden transition-all hover:shadow-xl hover:border-secondary/50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+                      className={`group relative flex h-full flex-col overflow-hidden transition-all hover:shadow-xl hover:border-secondary/50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${service.image_url ? "pt-0" : ""}`}
                     >
-                    <div className="absolute right-0 top-0 h-32 w-32 bg-gradient-to-br from-secondary/10 to-transparent rounded-bl-full" />
+                    {service.image_url ? (
+                      <div className="relative aspect-video w-full overflow-hidden bg-gradient-to-br from-secondary/20 to-muted">
+                        <Image
+                          src={resolveImageUrl(service.image_url)}
+                          alt={service.name}
+                          fill
+                          sizes="(max-width: 768px) 100vw, 33vw"
+                          className="object-cover transition-transform duration-700 group-hover:scale-105"
+                        />
+                      </div>
+                    ) : (
+                      <div className="absolute right-0 top-0 h-32 w-32 bg-gradient-to-br from-secondary/10 to-transparent rounded-bl-full" />
+                    )}
                     <CardHeader className="relative">
                       <CardTitle className="text-xl mb-2">{service.name}</CardTitle>
                       <div className="flex items-baseline gap-2">

--- a/frontend/src/app/services/[id]/page.tsx
+++ b/frontend/src/app/services/[id]/page.tsx
@@ -10,6 +10,7 @@
 
 import { use, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
@@ -32,6 +33,7 @@ import {
   getPackageFeatures,
   formatPrice,
 } from "@/lib/services";
+import { resolveImageUrl } from "@/lib/utils";
 import type { ServicePackage } from "@/types";
 
 interface ServiceDetailPageProps {
@@ -144,6 +146,18 @@ export default function ServiceDetailPage({ params }: ServiceDetailPageProps) {
         <div className="grid gap-8 lg:grid-cols-3">
           {/* Main column */}
           <div className="space-y-8 lg:col-span-2">
+            {pkg.image_url && (
+              <div className="relative aspect-[16/10] w-full overflow-hidden rounded-3xl border border-pink-50 bg-gradient-to-br from-secondary/20 to-muted shadow-lg">
+                <Image
+                  src={resolveImageUrl(pkg.image_url)}
+                  alt={pkg.name}
+                  fill
+                  priority
+                  sizes="(max-width: 1024px) 100vw, 66vw"
+                  className="object-cover"
+                />
+              </div>
+            )}
             <div>
               <div className="mb-3 flex flex-wrap items-center gap-2">
                 <Badge variant="secondary">

--- a/frontend/src/app/services/page.tsx
+++ b/frontend/src/app/services/page.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,8 @@ import {
   getPricingDescription,
   getPackageFeatures,
 } from "@/lib/services";
-import { Loader2 } from "lucide-react";
+import { resolveImageUrl } from "@/lib/utils";
+import { Loader2, Sparkles } from "lucide-react";
 
 export default function ServicesPage() {
   const router = useRouter();
@@ -102,7 +104,7 @@ export default function ServicesPage() {
                 const isPopular = pkg.package_type === "bridal_large" || pkg.package_type === "bride_only";
 
                 return (
-                  <Card
+                  <div
                     key={pkg.id}
                     id={pkg.id}
                     data-testid="service-card"
@@ -115,24 +117,48 @@ export default function ServicesPage() {
                         handleViewDetails(pkg.id);
                       }
                     }}
-                    className={`flex h-full flex-col cursor-pointer transition-all hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${isPopular ? "service-card package-card border-secondary shadow-lg" : "service-card package-card"}`}
+                    className={`service-card package-card group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-[2rem] border bg-white transition-all duration-500 hover:-translate-y-1 hover:shadow-2xl hover:shadow-pink-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${isPopular ? "border-secondary" : "border-pink-50"}`}
                   >
-                    <CardHeader>
-                      <div className="flex items-start justify-between">
-                        <div>
-                          <CardTitle className="text-2xl">{pkg.name}</CardTitle>
-                          {pkg.description && (
-                            <CardDescription className="mt-2">
-                              {pkg.description}
-                            </CardDescription>
-                          )}
+                    {/* Showcase image */}
+                    <div className="relative aspect-[4/3] overflow-hidden bg-gradient-to-br from-secondary/20 to-muted">
+                      {pkg.image_url ? (
+                        <Image
+                          src={resolveImageUrl(pkg.image_url)}
+                          alt={pkg.name}
+                          fill
+                          sizes="(max-width: 768px) 100vw, 50vw"
+                          className="object-cover transition-transform duration-700 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center">
+                          <Sparkles className="h-14 w-14 text-secondary/30" />
                         </div>
+                      )}
+                      {/* Legibility gradient */}
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/10 to-transparent" />
+                      {/* Badges */}
+                      <div className="absolute left-4 top-4 flex flex-wrap gap-2">
+                        <span className="inline-flex items-center rounded-full bg-white/90 px-3 py-1 text-[10px] font-black uppercase tracking-tighter text-pink-600 shadow-sm backdrop-blur-sm">
+                          {getPackageTypeName(pkg.package_type)}
+                        </span>
                         {isPopular && (
-                          <Badge variant="secondary">Popular</Badge>
+                          <span className="inline-flex items-center rounded-full bg-pink-600 px-3 py-1 text-[10px] font-black uppercase tracking-tighter text-white shadow-lg">
+                            Popular
+                          </span>
                         )}
                       </div>
-                    </CardHeader>
-                    <CardContent className="flex flex-1 flex-col space-y-6">
+                      {/* Name overlaid on image */}
+                      <h3 className="absolute inset-x-0 bottom-0 p-5 text-2xl font-bold text-white drop-shadow-md">
+                        {pkg.name}
+                      </h3>
+                    </div>
+
+                    {/* Content */}
+                    <div className="flex flex-1 flex-col space-y-6 p-6">
+                      {pkg.description && (
+                        <p className="text-sm text-muted-foreground">{pkg.description}</p>
+                      )}
+
                       {/* Features */}
                       <div className="flex-1">
                         <h4 className="mb-3 font-semibold">What&apos;s Included:</h4>
@@ -176,8 +202,8 @@ export default function ServicesPage() {
                           />
                         </div>
                       </div>
-                    </CardContent>
-                  </Card>
+                    </div>
+                  </div>
                 );
               })}
             </div>

--- a/frontend/src/components/admin/ServiceImageUpload.tsx
+++ b/frontend/src/components/admin/ServiceImageUpload.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Image from "next/image";
+import axios from "axios";
+import { ImagePlus, Loader2, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { resolveImageUrl } from "@/lib/utils";
+import { extractErrorMessage } from "@/lib/error-utils";
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+interface ServiceImageUploadProps {
+  packageId: string;
+  imageUrl?: string | null;
+  onChange: (url: string | null) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Single showcase-image uploader for a service package. Uploads immediately to
+ * the admin service image endpoint (the package already exists on the edit
+ * page) and reports the resulting URL back to the parent.
+ */
+export function ServiceImageUpload({
+  packageId,
+  imageUrl,
+  onChange,
+  disabled,
+}: ServiceImageUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+
+  const getToken = async (): Promise<string | null> => {
+    const session = await fetch("/api/auth/session").then((res) => res.json());
+    return session?.accessToken ?? null;
+  };
+
+  const handleSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Allow re-selecting the same file later.
+    e.target.value = "";
+    if (!file) return;
+
+    setError("");
+
+    if (!file.type.startsWith("image/")) {
+      setError("Please select an image file.");
+      return;
+    }
+    if (file.size > MAX_SIZE_BYTES) {
+      setError("Image must be 10MB or smaller.");
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+      const token = await getToken();
+      if (!token) {
+        setError("Authentication required.");
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await axios.post(
+        `${apiUrl}/api/admin/services/${packageId}/image`,
+        formData,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      );
+
+      onChange(res.data?.image_url ?? null);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Failed to upload image"));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setError("");
+    setUploading(true);
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+      const token = await getToken();
+      if (!token) {
+        setError("Authentication required.");
+        return;
+      }
+      await axios.delete(`${apiUrl}/api/admin/services/${packageId}/image`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      onChange(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Failed to remove image"));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <Label>Showcase Image</Label>
+      <p className="text-sm text-muted-foreground">
+        A strong photo of this service. Shown on the services page and detail
+        page. JPG/PNG/WebP, up to 10MB.
+      </p>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <div className="relative h-40 w-full overflow-hidden rounded-xl border border-border bg-muted sm:w-64">
+          {imageUrl ? (
+            <Image
+              src={resolveImageUrl(imageUrl)}
+              alt="Service showcase"
+              fill
+              sizes="256px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+              <ImagePlus className="h-8 w-8" />
+              <span className="text-xs">No image yet</span>
+            </div>
+          )}
+          {uploading && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <Loader2 className="h-6 w-6 animate-spin text-white" />
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleSelect}
+            disabled={disabled || uploading}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => inputRef.current?.click()}
+            disabled={disabled || uploading}
+          >
+            <ImagePlus className="mr-2 h-4 w-4" />
+            {imageUrl ? "Replace image" : "Upload image"}
+          </Button>
+          {imageUrl && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleRemove}
+              disabled={disabled || uploading}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Remove
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,6 +99,7 @@ export interface ServicePackage {
   min_maids?: number;
   includes_facial: boolean;
   duration_minutes?: number;
+  image_url?: string;
   is_active: boolean;
   display_order: number;
   created_at: string;


### PR DESCRIPTION
## Why
Services were text/price-only, which doesn't convert. This adds a single showcase image per service and leads the UI with it — "visual sells more than text."

## Backend
- **Migration `f7a8b9c0d1e2`**: nullable `image_url` column on `service_packages` (chained to head; auto-applies via Render `startCommand: alembic upgrade head`).
- **Schema**: `image_url` on `ServicePackageBase`/`Update` (present in all responses).
- **Admin endpoints** (`admin`-guarded): `POST /api/admin/services/{id}/image` (multipart, 10MB + image-type validation) and `DELETE …/image`. Reuse the existing product-image storage pipeline (`file_storage.upload_file` → S3 in prod / local in dev) and clean up the previous file on replace/remove.

## Frontend
- **Services listing card**: redesigned to the pink card aesthetic (`rounded-[2rem]`, hover lift/shadow) with an edge-to-edge 4:3 image, type/Popular badges, and the name overlaid; Sparkles fallback when no image.
- **Service detail**: `priority` hero image (16:10) at the top of the main column.
- **Homepage featured services**: edge-to-edge image at the card top when present.
- **Admin**: new reusable `ServiceImageUpload` component (preview + upload/replace/remove, client validation) on the service edit page; hint on the create page to add the image after saving (upload needs the service to exist, same as products).
- `image_url` added to the `ServicePackage` type.

## Verification
- Backend modules import cleanly; `alembic heads` = single head.
- `npm run type-check` and `npm run build` pass (exit 0).
- End-to-end URL handling confirmed: S3 https URLs → `resolveImageUrl` passthrough → `next.config` `remotePatterns` (https) already allowed.

## Not run locally
Live migration + upload — no DB/Docker in the dev env. The migration is a trivial nullable `add_column` and applies on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)