### PR TITLE
feat(services): featured flag for homepage service curation

### DIFF
--- a/backend/alembic/versions/a3b4c5d6e7f8_add_is_featured_to_service_packages.py
+++ b/backend/alembic/versions/a3b4c5d6e7f8_add_is_featured_to_service_packages.py
@@ -1,0 +1,32 @@
+"""add is_featured to service_packages
+
+Revision ID: a3b4c5d6e7f8
+Revises: f7a8b9c0d1e2
+Create Date: 2026-07-08
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3b4c5d6e7f8"
+down_revision: Union[str, None] = "f7a8b9c0d1e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "service_packages",
+        sa.Column("is_featured", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.create_index(
+        "ix_service_packages_is_featured", "service_packages", ["is_featured"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_service_packages_is_featured", table_name="service_packages")
+    op.drop_column("service_packages", "is_featured")

--- a/backend/app/api/routes/service_packages.py
+++ b/backend/app/api/routes/service_packages.py
@@ -44,6 +44,7 @@ async def list_packages(
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
     package_type: Optional[str] = Query(None, description="Filter by package type"),
     is_active: Optional[bool] = Query(None, description="Filter by active status"),
+    is_featured: Optional[bool] = Query(None, description="Filter by featured status"),
     search: Optional[str] = Query(None, description="Search in name and description"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user)
@@ -68,6 +69,7 @@ async def list_packages(
         limit=page_size,
         package_type=package_type,
         is_active=is_active,
+        is_featured=is_featured,
         search=search
     )
 

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -40,6 +40,7 @@ class ServicePackage(Base):
     includes_facial = Column(Boolean, default=False)
     duration_minutes = Column(Integer)
     image_url = Column(String(500))
+    is_featured = Column(Boolean, default=False, nullable=False, index=True)
     is_active = Column(Boolean, default=True, index=True)
     display_order = Column(Integer, default=0, index=True)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow)

--- a/backend/app/routers/services.py
+++ b/backend/app/routers/services.py
@@ -25,6 +25,7 @@ async def list_active_packages(
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
     package_type: Optional[str] = Query(None, description="Filter by package type"),
+    is_featured: Optional[bool] = Query(None, description="Filter by featured status"),
     db: Session = Depends(get_db)
 ):
     """
@@ -38,6 +39,7 @@ async def list_active_packages(
     - **page**: Page number (default: 1)
     - **page_size**: Items per page (default: 20, max: 100)
     - **package_type**: Filter by package type (bridal_large, bridal_small, bride_only, regular, classes)
+    - **is_featured**: Filter by featured status (true = homepage featured services)
 
     Returns:
     - Service packages with pricing breakdown
@@ -51,7 +53,8 @@ async def list_active_packages(
         skip=skip,
         limit=page_size,
         package_type=package_type,
-        is_active=True  # Force only active packages
+        is_active=True,  # Force only active packages
+        is_featured=is_featured
     )
 
     total_pages = math.ceil(total / page_size) if total > 0 else 1

--- a/backend/app/schemas/service_package.py
+++ b/backend/app/schemas/service_package.py
@@ -25,6 +25,7 @@ class ServicePackageBase(BaseModel):
     includes_facial: bool = Field(False, description="Whether package includes facial")
     duration_minutes: Optional[int] = Field(None, gt=0, description="Service duration in minutes")
     image_url: Optional[str] = Field(None, max_length=500, description="Service showcase image URL")
+    is_featured: bool = Field(False, description="Whether package is featured on the homepage (max 3)")
     is_active: bool = Field(True, description="Whether package is active")
     display_order: int = Field(0, ge=0, description="Display order (lower = earlier)")
 
@@ -75,6 +76,7 @@ class ServicePackageUpdate(BaseModel):
     includes_facial: Optional[bool] = None
     duration_minutes: Optional[int] = Field(None, gt=0)
     image_url: Optional[str] = Field(None, max_length=500)
+    is_featured: Optional[bool] = None
     is_active: Optional[bool] = None
     display_order: Optional[int] = Field(None, ge=0)
 

--- a/backend/app/services/service_package_service.py
+++ b/backend/app/services/service_package_service.py
@@ -11,6 +11,21 @@ from app.models.service import ServicePackage
 from app.schemas.service_package import ServicePackageCreate, ServicePackageUpdate
 from app.services.file_storage_service import file_storage
 
+# Maximum number of packages that can be featured on the homepage at once
+MAX_FEATURED_PACKAGES = 3
+
+
+def _assert_featured_slot_available(db: Session, exclude_id: Optional[UUID] = None) -> None:
+    """Raise ValueError if all homepage featured slots are already taken."""
+    query = db.query(ServicePackage).filter(ServicePackage.is_featured == True)  # noqa: E712
+    if exclude_id is not None:
+        query = query.filter(ServicePackage.id != exclude_id)
+    if query.count() >= MAX_FEATURED_PACKAGES:
+        raise ValueError(
+            f"A maximum of {MAX_FEATURED_PACKAGES} services can be featured on the homepage. "
+            "Unfeature another service first."
+        )
+
 
 def get_package_by_id(db: Session, package_id: UUID) -> Optional[ServicePackage]:
     """Get service package by ID"""
@@ -28,6 +43,7 @@ def get_packages(
     limit: int = 100,
     package_type: Optional[str] = None,
     is_active: Optional[bool] = None,
+    is_featured: Optional[bool] = None,
     search: Optional[str] = None
 ) -> tuple[list[ServicePackage], int]:
     """
@@ -39,6 +55,7 @@ def get_packages(
         limit: Maximum number of records to return
         package_type: Filter by package type
         is_active: Filter by active status
+        is_featured: Filter by featured status
         search: Search in name and description
 
     Returns:
@@ -52,6 +69,9 @@ def get_packages(
 
     if is_active is not None:
         query = query.filter(ServicePackage.is_active == is_active)
+
+    if is_featured is not None:
+        query = query.filter(ServicePackage.is_featured == is_featured)
 
     if search:
         search_term = f"%{search}%"
@@ -112,6 +132,10 @@ def create_package(db: Session, package_data: ServicePackageCreate) -> ServicePa
         if package_data.max_maids < package_data.min_maids:
             raise ValueError("max_maids must be greater than or equal to min_maids")
 
+    # Enforce homepage featured slot limit
+    if package_data.is_featured:
+        _assert_featured_slot_available(db)
+
     # Create package
     package = ServicePackage(
         package_type=package_data.package_type.lower(),
@@ -125,6 +149,7 @@ def create_package(db: Session, package_data: ServicePackageCreate) -> ServicePa
         min_maids=package_data.min_maids,
         includes_facial=package_data.includes_facial,
         duration_minutes=package_data.duration_minutes,
+        is_featured=package_data.is_featured,
         is_active=package_data.is_active,
         display_order=package_data.display_order
     )
@@ -201,6 +226,11 @@ def update_package(
 
     if package_data.duration_minutes is not None:
         package.duration_minutes = package_data.duration_minutes
+
+    if package_data.is_featured is not None:
+        if package_data.is_featured and not package.is_featured:
+            _assert_featured_slot_available(db, exclude_id=package_id)
+        package.is_featured = package_data.is_featured
 
     if package_data.is_active is not None:
         package.is_active = package_data.is_active

--- a/frontend/src/app/admin/services/[id]/page.tsx
+++ b/frontend/src/app/admin/services/[id]/page.tsx
@@ -32,6 +32,7 @@ const servicePackageSchema = z.object({
   min_maids: z.number().int().min(0, "Min maids cannot be negative"),
   includes_facial: z.boolean(),
   duration_minutes: z.number().int().min(1, "Duration must be positive").optional(),
+  is_featured: z.boolean(),
   is_active: z.boolean(),
   display_order: z.number().int().min(0, "Display order cannot be negative"),
 }).refine(
@@ -79,6 +80,7 @@ export default function EditServicePackage() {
     min_maids: 0,
     includes_facial: false,
     duration_minutes: undefined,
+    is_featured: false,
     is_active: true,
     display_order: 0,
   });
@@ -138,6 +140,7 @@ export default function EditServicePackage() {
           min_maids: pkg.min_maids || 0,
           includes_facial: pkg.includes_facial ?? false,
           duration_minutes: mins,
+          is_featured: pkg.is_featured ?? false,
           is_active: pkg.is_active ?? true,
           display_order: pkg.display_order || 0,
         });
@@ -609,6 +612,17 @@ export default function EditServicePackage() {
                 </Label>
               </div>
             )}
+
+            <div className="flex items-center gap-2">
+              <Switch
+                id="is_featured"
+                checked={formData.is_featured}
+                onCheckedChange={(checked) => setFormData({ ...formData, is_featured: checked })}
+              />
+              <Label htmlFor="is_featured" className="font-normal">
+                Feature on homepage (max 3 services)
+              </Label>
+            </div>
 
             <div className="flex items-center gap-2">
               <Switch

--- a/frontend/src/app/admin/services/new/page.tsx
+++ b/frontend/src/app/admin/services/new/page.tsx
@@ -31,6 +31,7 @@ const servicePackageSchema = z.object({
   min_maids: z.number().int().min(0, "Min maids cannot be negative"),
   includes_facial: z.boolean(),
   duration_minutes: z.number().int().min(1, "Duration must be positive").optional(),
+  is_featured: z.boolean(),
   is_active: z.boolean(),
   display_order: z.number().int().min(0, "Display order cannot be negative"),
 }).refine(
@@ -72,6 +73,7 @@ export default function NewServicePackage() {
     min_maids: 0,
     includes_facial: false,
     duration_minutes: undefined,
+    is_featured: false,
     is_active: true,
     display_order: 0,
   });
@@ -529,6 +531,17 @@ export default function NewServicePackage() {
                 </Label>
               </div>
             )}
+
+            <div className="flex items-center gap-2">
+              <Switch
+                id="is_featured"
+                checked={formData.is_featured}
+                onCheckedChange={(checked) => setFormData({ ...formData, is_featured: checked })}
+              />
+              <Label htmlFor="is_featured" className="font-normal">
+                Feature on homepage (max 3 services)
+              </Label>
+            </div>
 
             <div className="flex items-center gap-2">
               <Switch

--- a/frontend/src/app/admin/services/page.tsx
+++ b/frontend/src/app/admin/services/page.tsx
@@ -31,6 +31,7 @@ interface ServicePackage {
   min_maids: number;
   includes_facial: boolean;
   duration_minutes?: number;
+  is_featured: boolean;
   is_active: boolean;
   display_order: number;
   created_at: string;
@@ -336,11 +337,18 @@ export default function ServicePackagesManagement() {
                               {pkg.description}
                             </div>
                           )}
-                          {pkg.includes_facial && (
-                            <span className="inline-flex mt-1 px-2 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-800">
-                              Includes Facial
-                            </span>
-                          )}
+                          <div className="flex flex-wrap gap-1">
+                            {pkg.is_featured && (
+                              <span className="inline-flex mt-1 px-2 py-0.5 text-xs font-medium rounded bg-pink-100 text-pink-800">
+                                ★ Featured
+                              </span>
+                            )}
+                            {pkg.includes_facial && (
+                              <span className="inline-flex mt-1 px-2 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-800">
+                                Includes Facial
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </td>
                       <td className="px-6 py-4">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -71,6 +71,7 @@ interface ServicePackage {
   includes_facial: boolean;
   duration_minutes: number;
   image_url?: string;
+  is_featured?: boolean;
   display_order: number;
 }
 
@@ -103,11 +104,20 @@ export default function Home() {
   useEffect(() => {
     async function fetchData() {
       try {
-        // Fetch featured services (bridal packages)
-        const servicesRes = await fetch(`${API_BASE_URL}${API_ENDPOINTS.SERVICES.LIST}?limit=3`);
+        // Fetch featured services (admin-curated, max 3)
+        const servicesRes = await fetch(`${API_BASE_URL}${API_ENDPOINTS.SERVICES.LIST}?is_featured=true&page_size=3`);
         if (servicesRes.ok) {
           const servicesData = await servicesRes.json();
-          setFeaturedServices(servicesData.items || servicesData);
+          let serviceItems: ServicePackage[] = servicesData.items || servicesData;
+          // Fallback: if no services are flagged as featured yet, show the first 3
+          if (!serviceItems.length) {
+            const fallbackRes = await fetch(`${API_BASE_URL}${API_ENDPOINTS.SERVICES.LIST}?page_size=3`);
+            if (fallbackRes.ok) {
+              const fallbackData = await fallbackRes.json();
+              serviceItems = fallbackData.items || fallbackData;
+            }
+          }
+          setFeaturedServices(serviceItems);
         }
 
         // Fetch featured products

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -100,6 +100,7 @@ export interface ServicePackage {
   includes_facial: boolean;
   duration_minutes?: number;
   image_url?: string;
+  is_featured: boolean;
   is_active: boolean;
   display_order: number;
   created_at: string;


### PR DESCRIPTION
## Summary
- Adds `is_featured` to `service_packages` (indexed, default false) + Alembic migration `a3b4c5d6e7f8` — runs automatically on Render deploy
- Server-side cap: max **3** featured services; flagging a 4th returns a clear 400 shown in the admin form
- `?is_featured=true` filter on public `GET /api/services` and admin list
- Homepage "Featured Services" now shows the admin-curated 3 (previously `?limit=3` was silently ignored — the section rendered *all* active services); falls back to the first 3 active services if none are flagged yet
- Admin: "Feature on homepage (max 3 services)" switch on new/edit forms, ★ Featured badge in the services list

## Testing
- Backend files compile; migration chain verified linear with single head
- `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)