### PR TITLE
fix(auth): close production auth & deploy blockers (readiness phase 1)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,7 +20,9 @@ class Settings(BaseSettings):
     # Application
     APP_NAME: str = "Glam by Lynn API"
     APP_VERSION: str = "1.0.0"
-    DEBUG: bool = True
+    # Default to the safe (production-like) posture; opt into DEBUG explicitly
+    # in local development via the environment/.env.
+    DEBUG: bool = False
     ENVIRONMENT: str = "development"
 
     # Server

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -7,6 +7,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from datetime import timedelta
 
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token as google_id_token
+
 from app.core.database import get_db
 from app.core.security import create_access_token, create_refresh_token, verify_token
 from app.core.dependencies import get_current_user, get_current_active_user
@@ -30,12 +33,15 @@ async def google_auth(
     db: Session = Depends(get_db)
 ):
     """
-    Google OAuth authentication endpoint
-    Creates or retrieves user based on Google account info
-    Also links any guest orders/bookings if user previously placed orders as guest
+    Google OAuth authentication endpoint.
+
+    Verifies the Google-issued ID token server-side and creates or retrieves the
+    user from the *verified* token claims (email, sub). Client-supplied identity
+    is never trusted. Also links any guest orders/bookings placed under the same
+    verified email.
 
     Args:
-        auth_data: Google authentication data (email, googleId, name, image)
+        auth_data: Google authentication data (idToken, and optional name/image)
         db: Database session
 
     Returns:
@@ -43,15 +49,42 @@ async def google_auth(
         (guest data automatically linked if applicable)
 
     Raises:
-        HTTPException: If authentication fails
+        HTTPException: If the Google token is invalid or the email is unverified
     """
+    # Verify the ID token with Google. This validates the signature, audience
+    # (must equal our OAuth client id), issuer and expiry — raising ValueError
+    # on any failure.
+    try:
+        claims = google_id_token.verify_oauth2_token(
+            auth_data.id_token,
+            google_requests.Request(),
+            settings.GOOGLE_CLIENT_ID,
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Google credentials",
+        )
+
+    # Only trust a verified email address from the token claims.
+    if not claims.get("email") or not claims.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Google account email is not verified",
+        )
+
+    email = claims["email"]
+    google_id = claims["sub"]
+    name = auth_data.name or claims.get("name")
+    image = auth_data.image or claims.get("picture")
+
     # Use user service to handle OAuth login with guest data linking
     user, created, link_stats = user_service.get_or_create_user_from_oauth(
         db=db,
-        email=auth_data.email,
-        google_id=auth_data.google_id,
-        name=auth_data.name,
-        image=auth_data.image
+        email=email,
+        google_id=google_id,
+        name=name,
+        image=image
     )
 
     # Ensure user is active
@@ -196,60 +229,6 @@ async def logout(
     }
 
 
-@router.post("/token", response_model=TokenResponse)
-async def create_tokens_for_user(
-    user_id: str,
-    db: Session = Depends(get_db)
-):
-    """
-    Create access and refresh tokens for a user (internal use)
-    This endpoint is typically called after successful Google OAuth
-
-    Args:
-        user_id: User ID to create tokens for
-        db: Database session
-
-    Returns:
-        Access and refresh tokens
-
-    Raises:
-        HTTPException: If user not found
-    """
-    from uuid import UUID
-    try:
-        user = db.query(User).filter(User.id == UUID(user_id)).first()
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
-        )
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
-        )
-
-    if not user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="User account is inactive"
-        )
-
-    # Create tokens
-    access_token = create_access_token(
-        data={"sub": str(user.id), "email": user.email}
-    )
-    refresh_token = create_refresh_token(
-        data={"sub": str(user.id)}
-    )
-
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token
-    )
-
-
 @router.post("/guest", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def create_guest_user(
     email: str,
@@ -292,11 +271,14 @@ async def link_guest_data(
     db: Session = Depends(get_db)
 ):
     """
-    Manually link guest orders and bookings to authenticated user account
-    Useful for cases where email doesn't match exactly
+    Link guest orders and bookings to the authenticated user's account.
+
+    A user may only link guest data placed under their *own* verified email
+    address. Linking arbitrary emails would let any authenticated user absorb
+    another person's guest orders and bookings.
 
     Args:
-        guest_email: Email address used for guest orders/bookings
+        guest_email: Must match the authenticated user's own email
         current_user: Current authenticated user
         db: Database session
 
@@ -304,13 +286,19 @@ async def link_guest_data(
         Link statistics
 
     Raises:
-        HTTPException: If linking fails
+        HTTPException: If the email does not match the authenticated user
     """
+    if guest_email.strip().lower() != (current_user.email or "").strip().lower():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only link guest data for your own verified email address"
+        )
+
     try:
         link_stats = user_service.link_guest_data_to_user(
             db=db,
             user_id=current_user.id,
-            guest_email=guest_email
+            guest_email=current_user.email
         )
         return {
             "message": "Guest data successfully linked",

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -2,15 +2,19 @@
 Auth schemas for request/response validation
 """
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, Field
 from typing import Optional
 from uuid import UUID
 
 
 class GoogleAuthRequest(BaseModel):
-    """Request model for Google OAuth authentication"""
-    email: EmailStr
-    google_id: str = Field(..., alias="googleId")
+    """Request model for Google OAuth authentication.
+
+    Only the Google-issued ID token is trusted. The user's email and Google
+    account id are derived from the token's verified claims server-side — never
+    from client-supplied fields. ``name``/``image`` are display-only hints.
+    """
+    id_token: str = Field(..., alias="idToken", description="Google-issued OIDC ID token")
     name: Optional[str] = None
     image: Optional[str] = None
 

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -7,6 +7,10 @@ services:
     envVars:
       - key: PYTHON_VERSION
         value: 3.11
+      - key: ENVIRONMENT
+        value: production
+      - key: DEBUG
+        value: false
       - key: DATABASE_URL
         sync: false
       - key: SECRET_KEY

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,6 +3,7 @@ Comprehensive tests for authentication flow
 Tests Google OAuth, JWT tokens, guest users, and role checking
 """
 import pytest
+from unittest.mock import patch
 from fastapi import status
 from uuid import uuid4
 
@@ -12,19 +13,44 @@ from app.models.order import Order
 from app.models.booking import Booking
 
 
+@pytest.fixture
+def google_signin(client):
+    """Helper to perform a Google login with a *verified* ID token.
+
+    Patches the Google ID-token verifier so the supplied identity is treated as
+    a verified claim set, mirroring what Google returns for a real token. Tests
+    never send a raw email/googleId — only the verified token is trusted.
+    """
+    def _signin(email, google_id, name=None, image=None, email_verified=True):
+        claims = {
+            "email": email,
+            "sub": google_id,
+            "email_verified": email_verified,
+            "name": name,
+            "picture": image,
+        }
+        with patch(
+            "app.routers.auth.google_id_token.verify_oauth2_token",
+            return_value=claims,
+        ):
+            return client.post(
+                "/api/auth/google-login",
+                json={"idToken": "fake.id.token", "name": name, "image": image},
+            )
+
+    return _signin
+
+
 class TestGoogleOAuthFlow:
     """Test Google OAuth authentication flow"""
 
-    def test_google_login_new_user(self, client, db_session):
-        """Test Google login creates new user"""
-        response = client.post(
-            "/api/auth/google-login",
-            json={
-                "email": "newuser@gmail.com",
-                "googleId": "google123",
-                "name": "New User",
-                "image": "https://example.com/photo.jpg",
-            },
+    def test_google_login_new_user(self, client, db_session, google_signin):
+        """Test Google login creates new user from verified token claims"""
+        response = google_signin(
+            email="newuser@gmail.com",
+            google_id="google123",
+            name="New User",
+            image="https://example.com/photo.jpg",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -47,16 +73,13 @@ class TestGoogleOAuthFlow:
         assert user.google_id == "google123"
         assert user.is_active is True
 
-    def test_google_login_existing_user(self, client, regular_user):
+    def test_google_login_existing_user(self, client, regular_user, google_signin):
         """Test Google login with existing user"""
-        response = client.post(
-            "/api/auth/google-login",
-            json={
-                "email": regular_user.email,
-                "googleId": regular_user.google_id,
-                "name": "Updated Name",
-                "image": "https://example.com/new-photo.jpg",
-            },
+        response = google_signin(
+            email=regular_user.email,
+            google_id=regular_user.google_id,
+            name="Updated Name",
+            image="https://example.com/new-photo.jpg",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -67,7 +90,7 @@ class TestGoogleOAuthFlow:
         assert "accessToken" in data
         assert "refreshToken" in data
 
-    def test_google_login_inactive_user(self, client, db_session):
+    def test_google_login_inactive_user(self, client, db_session, google_signin):
         """Test Google login fails for inactive user"""
         # Create inactive user
         user = User(
@@ -78,27 +101,21 @@ class TestGoogleOAuthFlow:
         db_session.add(user)
         db_session.commit()
 
-        response = client.post(
-            "/api/auth/google-login",
-            json={
-                "email": "inactive@test.com",
-                "googleId": "inactive123",
-                "name": "Inactive User",
-            },
+        response = google_signin(
+            email="inactive@test.com",
+            google_id="inactive123",
+            name="Inactive User",
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "inactive" in response.json()["detail"].lower()
 
-    def test_google_login_admin_user(self, client, admin_user):
+    def test_google_login_admin_user(self, client, admin_user, google_signin):
         """Test Google login with admin user returns admin info"""
-        response = client.post(
-            "/api/auth/google-login",
-            json={
-                "email": admin_user.email,
-                "googleId": admin_user.google_id,
-                "name": admin_user.full_name,
-            },
+        response = google_signin(
+            email=admin_user.email,
+            google_id=admin_user.google_id,
+            name=admin_user.full_name,
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -106,6 +123,47 @@ class TestGoogleOAuthFlow:
 
         assert data["isAdmin"] is True
         assert data["adminRole"] == "super_admin"
+
+    def test_google_login_rejects_invalid_token(self, client, admin_user):
+        """An unverifiable ID token is rejected — no admin takeover by email."""
+        with patch(
+            "app.routers.auth.google_id_token.verify_oauth2_token",
+            side_effect=ValueError("Invalid token"),
+        ):
+            response = client.post(
+                "/api/auth/google-login",
+                json={"idToken": "forged", "name": "Attacker"},
+            )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_google_login_rejects_unverified_email(self, client, google_signin):
+        """A token whose email is not verified is rejected."""
+        response = google_signin(
+            email="unverified@gmail.com",
+            google_id="unverified999",
+            email_verified=False,
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_google_login_requires_id_token(self, client):
+        """The endpoint requires an idToken — a bare email is not accepted."""
+        response = client.post(
+            "/api/auth/google-login",
+            json={"email": "attacker@gmail.com", "googleId": "x"},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_token_minting_endpoint_removed(self, client, admin_user):
+        """The unauthenticated /auth/token minting endpoint no longer exists."""
+        response = client.post(f"/api/auth/token?user_id={admin_user.id}")
+
+        assert response.status_code in (
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+        )
 
 
 class TestJWTTokens:
@@ -283,7 +341,7 @@ class TestGuestUserCreation:
 class TestGuestDataLinking:
     """Test linking guest orders/bookings to authenticated user"""
 
-    def test_google_login_links_guest_orders(self, client, db_session):
+    def test_google_login_links_guest_orders(self, client, db_session, google_signin):
         """Test Google login automatically links guest orders"""
         # Create guest user with email
         guest_user = User(email="link@test.com", google_id=None)
@@ -291,38 +349,41 @@ class TestGuestDataLinking:
         db_session.commit()
         db_session.refresh(guest_user)
 
-        # Create guest order (simplified - would need service package and location)
-        # This is a conceptual test - actual implementation may vary
-        # order = Order(user_id=guest_user.id, ...)
-        # db_session.add(order)
-        # db_session.commit()
-
-        # Login with Google using same email
-        response = client.post(
-            "/api/auth/google-login",
-            json={
-                "email": "link@test.com",
-                "googleId": "google456",
-                "name": "Linked User",
-            },
+        # Login with Google using same (verified) email
+        response = google_signin(
+            email="link@test.com",
+            google_id="google456",
+            name="Linked User",
         )
 
         assert response.status_code == status.HTTP_200_OK
         # Guest data should be linked automatically
 
-    def test_manual_guest_data_linking(self, client, regular_user):
-        """Test manual guest data linking endpoint"""
+    def test_manual_linking_own_email_allowed(self, client, regular_user):
+        """A user may link guest data placed under their own verified email."""
         token = create_access_token(
             data={"sub": str(regular_user.id), "email": regular_user.email}
         )
 
         response = client.post(
-            f"/api/auth/link-guest-data?guest_email=guest@test.com",
+            f"/api/auth/link-guest-data?guest_email={regular_user.email}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
-        # May return 400 if no guest user exists, which is expected
-        assert response.status_code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_manual_linking_other_email_forbidden(self, client, regular_user):
+        """A user may NOT link guest data belonging to someone else's email."""
+        token = create_access_token(
+            data={"sub": str(regular_user.id), "email": regular_user.email}
+        )
+
+        response = client.post(
+            "/api/auth/link-guest-data?guest_email=victim@test.com",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 class TestAdminRoleChecking:

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -52,28 +52,19 @@ export const authOptions: NextAuthOptions = {
     async signIn({ user, account }) {
       if (!account) return false;
 
+      // The backend only trusts the Google-issued ID token, which it verifies
+      // server-side. Bail out if the provider did not return one.
+      if (!account.id_token) return false;
+
       try {
         const url = `${API_BASE_URL}${API_ENDPOINTS.AUTH.GOOGLE_LOGIN}`;
-        console.log('[signIn callback] Attempting to call backend at:', url);
-        console.log('[signIn callback] Request data:', {
-          email: user.email,
-          googleId: account.providerAccountId,
+
+        // Send only the verified ID token (plus display-only profile hints).
+        const response = await axios.post(url, {
+          idToken: account.id_token,
           name: user.name,
           image: user.image,
         });
-
-        // Send Google auth info to backend
-        const response = await axios.post(
-          url,
-          {
-            email: user.email,
-            googleId: account.providerAccountId,
-            name: user.name,
-            image: user.image,
-          }
-        );
-
-        console.log('[signIn callback] Backend response:', response.data);
 
         // Store backend user data and JWT tokens
         if (response.data) {
@@ -86,12 +77,11 @@ export const authOptions: NextAuthOptions = {
 
         return true;
       } catch (error) {
-        console.error("[signIn callback] Error details:", {
-          message: error instanceof Error ? error.message : 'Unknown error',
-          response: (error as any)?.response?.data,
-          status: (error as any)?.response?.status,
-          code: (error as any)?.code,
-        });
+        // Never log token/response bodies or PII. Surface only a status code.
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        console.error(
+          `[signIn] Backend authentication failed${status ? ` (status ${status})` : ""}`
+        );
         return false;
       }
     },
@@ -177,13 +167,17 @@ export const authOptions: NextAuthOptions = {
     },
   },
 
-  // Events for logging
+  // Events for logging (development only — never log PII in production)
   events: {
     async signIn({ user }) {
-      console.log(`User signed in: ${user.email}`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`User signed in: ${user.email}`);
+      }
     },
     async signOut({ token }) {
-      console.log(`User signed out: ${token.email}`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`User signed out: ${token.email}`);
+      }
     },
   },
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,22 @@
+/**
+ * Next.js middleware — server-side route protection.
+ *
+ * Guards every /admin/* route by requiring a NextAuth session whose backend
+ * JWT is flagged `isAdmin`. This runs at the edge before any admin page or its
+ * JS bundle is served, so non-admins never receive admin code or data — a
+ * defense-in-depth layer on top of the backend's per-request Bearer checks.
+ */
+import { withAuth } from "next-auth/middleware";
+
+export default withAuth({
+  callbacks: {
+    authorized: ({ token }) => token?.isAdmin === true,
+  },
+  pages: {
+    signIn: "/auth/signin",
+  },
+});
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};


### PR DESCRIPTION
## Phase 1 of the production readiness roadmap — auth & deploy blockers

Closes the show-stopping auth-bypass and deploy-config issues that must clear before any public launch. Every finding was verified against source before fixing.

### Critical
- **C1 — Google login now verified server-side.** `/auth/google-login` verifies the Google ID token (`verify_oauth2_token`: signature, audience, issuer, expiry) and derives `email`/`sub` from the *verified* claims, rejecting unverified emails. Previously it trusted a client-supplied `{email, googleId}`, allowing anyone to mint admin tokens. Frontend now sends `idToken`.
- **C2 — Removed `/auth/token`.** This unauthenticated endpoint minted access+refresh tokens for any `user_id`. Deleted.
- **C3 — Secure deploy posture.** Added `ENVIRONMENT=production` + `DEBUG=false` to `render.yaml`; flipped the `DEBUG` default to `False` so production guards fail closed instead of silently no-opping on dev defaults.

### High
- **H1 — Guest-data linking locked down.** `/auth/link-guest-data` now 403s unless the email matches the caller's own verified email (was an IDOR letting any user absorb another person's guest orders/bookings).
- **H5 — No more token/PII in logs.** Removed the NextAuth `console.log` that dumped both backend tokens; error logging emits a status code only; sign-in/out event logs gated to development.
- **H8 — Server-side `/admin` protection.** New `frontend/src/middleware.ts` (`withAuth`, `authorized: token.isAdmin === true`, `matcher: /admin/:path*`) so non-admins never receive admin bundles/data.

### Tests
Updated `test_auth.py` to mock Google verification and send `idToken`; added negative tests: forged token → 401, unverified email → 401, bare email → 422, `/auth/token` gone → 404/405, cross-email linking → 403.

### Verification
- Backend compiles; `app.main` imports cleanly; `/auth/token` de-registered; Google verifier wired.
- Frontend `tsc --noEmit` passes; `next-auth@4` supports the middleware.
- Full pytest suite requires Postgres (unavailable in this env; Docker down) — runs under CI.

### ⚠️ Operator action required before/at deploy
- **Rotate `SECRET_KEY`** in the Render dashboard to a strong 32+ char value. With `ENVIRONMENT=production` now active, the app will **refuse to boot** if it's still the default (fail-closed).
- **Scrub existing Vercel logs** — tokens were logged historically (H5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)