### PR TITLE
fix: money-path correctness & delivery hardening (readiness phase 2)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,8 +55,11 @@ class Settings(BaseSettings):
     S3_BUCKET_NAME: str = ""
 
     # Email
+    EMAIL_PROVIDER: str = "console"  # console | resend | sendgrid
     RESEND_API_KEY: str = ""
+    SENDGRID_API_KEY: str = ""
     FROM_EMAIL: str = "noreply@glambylynn.com"
+    EMAIL_FROM_NAME: str = "Glam by Lynn"
 
     # Admin
     ADMIN_EMAILS: List[str] = []
@@ -132,6 +135,18 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "DEBUG should be set to False in production for security"
                 )
+
+            # Email must actually be deliverable in production. The console
+            # provider only prints to logs while reporting success, so orders
+            # and bookings would silently never notify anyone.
+            if self.EMAIL_PROVIDER == "console":
+                raise ValueError(
+                    "EMAIL_PROVIDER must be a real provider (e.g. 'resend') in production, not 'console'"
+                )
+            if self.EMAIL_PROVIDER == "resend" and not self.RESEND_API_KEY:
+                raise ValueError("RESEND_API_KEY must be set when EMAIL_PROVIDER=resend")
+            if self.EMAIL_PROVIDER == "sendgrid" and not self.SENDGRID_API_KEY:
+                raise ValueError("SENDGRID_API_KEY must be set when EMAIL_PROVIDER=sendgrid")
 
         return self
 

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -2,6 +2,8 @@
 Booking service
 Business logic for booking availability and management
 """
+import secrets
+import string
 from datetime import datetime, timedelta
 from datetime import date as date_type
 from datetime import time as time_type
@@ -10,6 +12,7 @@ from uuid import UUID
 from decimal import Decimal, ROUND_UP
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, or_, func
+from sqlalchemy.exc import IntegrityError
 
 from app.models.booking import Booking
 from app.models.service import CalendarAvailability, ServicePackage, TransportLocation
@@ -188,35 +191,22 @@ def get_availability(
     )
 
 
-def generate_booking_number(db: Session) -> str:
+def generate_booking_number() -> str:
     """
-    Generate a unique booking number
+    Generate a booking number.
 
-    Format: BK{YYYYMMDD}{####} where #### is a 4-digit counter
+    Format: BK{YYYYMMDD}{#####} where ##### is a random 5-digit suffix.
 
-    Args:
-        db: Database session
-
-    Returns:
-        Unique booking number
+    A random suffix (rather than a count-then-format counter) avoids the
+    check-then-insert race where two concurrent bookings compute the same
+    sequential number. The unique constraint on ``booking_number`` plus the
+    retry loop in ``create_booking`` guarantee uniqueness even on a rare
+    random collision.
     """
     today = date_type.today()
     date_prefix = f"BK{today.strftime('%Y%m%d')}"
-
-    # Get the count of bookings created today
-    count = db.query(func.count(Booking.id)).filter(
-        Booking.booking_number.like(f"{date_prefix}%")
-    ).scalar() or 0
-
-    # Generate number with padding
-    booking_number = f"{date_prefix}{(count + 1):04d}"
-
-    # Ensure uniqueness (in case of concurrent requests)
-    while db.query(Booking).filter(Booking.booking_number == booking_number).first():
-        count += 1
-        booking_number = f"{date_prefix}{(count + 1):04d}"
-
-    return booking_number
+    suffix = "".join(secrets.choice(string.digits) for _ in range(5))
+    return f"{date_prefix}{suffix}"
 
 
 def calculate_booking_price(
@@ -334,7 +324,7 @@ def create_booking(
     deposit_amount = (total_amount * Decimal('0.5')).quantize(Decimal('0.01'), rounding=ROUND_UP)
 
     # Generate booking number
-    booking_number = generate_booking_number(db)
+    booking_number = generate_booking_number()
 
     # Create booking
     booking = Booking(
@@ -365,8 +355,18 @@ def create_booking(
         status="pending"
     )
 
-    db.add(booking)
-    db.commit()
+    # Persist, retrying on the rare chance two bookings drew the same random
+    # number (the unique constraint raises IntegrityError for the loser).
+    for attempt in range(5):
+        db.add(booking)
+        try:
+            db.commit()
+            break
+        except IntegrityError:
+            db.rollback()
+            if attempt == 4:
+                raise
+            booking.booking_number = generate_booking_number()
     db.refresh(booking)
 
     # TODO: Send confirmation email (implement email service)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,6 +1,5 @@
 """Email service for sending transactional emails."""
 import logging
-import os
 import re
 from typing import Optional, Dict, Any
 from datetime import datetime
@@ -30,18 +29,21 @@ class EmailService:
 
     def __init__(self):
         """Initialize email service with configured provider."""
-        self.provider = os.getenv("EMAIL_PROVIDER", "console")  # console, resend, sendgrid, smtp
-        self.from_email = os.getenv("EMAIL_FROM", "noreply@glambylynn.com")
-        self.from_name = os.getenv("EMAIL_FROM_NAME", "Glam by Lynn")
+        # Read from centralized settings so config validation (fail-fast in
+        # production) applies and the provider/from-address can't silently drift
+        # from what the deploy sets.
+        self.provider = settings.EMAIL_PROVIDER  # console | resend | sendgrid
+        self.from_email = settings.FROM_EMAIL
+        self.from_name = settings.EMAIL_FROM_NAME
 
         if self.provider == "resend":
             if not RESEND_AVAILABLE:
                 raise ImportError("Resend package not installed. Run: pip install resend")
-            resend.api_key = os.getenv("RESEND_API_KEY")
+            resend.api_key = settings.RESEND_API_KEY
         elif self.provider == "sendgrid":
             if not SENDGRID_AVAILABLE:
                 raise ImportError("SendGrid package not installed. Run: pip install sendgrid")
-            self.sendgrid_key = os.getenv("SENDGRID_API_KEY")
+            self.sendgrid_key = settings.SENDGRID_API_KEY
 
     def send_email(
         self,

--- a/backend/app/services/file_storage_service.py
+++ b/backend/app/services/file_storage_service.py
@@ -53,6 +53,16 @@ class FileStorageService:
         try:
             return provider.upload(file_data, file_key, content_type)
         except Exception as e:
+            # In production, falling back to the ephemeral local disk would lose
+            # the file on the next redeploy while persisting a dead URL — fail
+            # loudly instead so the caller sees the error.
+            from app.core.config import settings
+            if settings.ENVIRONMENT == "production":
+                logger.error(
+                    f"Upload via {type(provider).__name__} failed in production; not "
+                    f"falling back to ephemeral local storage: {e}"
+                )
+                raise
             logger.warning(f"Upload via {type(provider).__name__} failed, falling back to local: {e}")
             return LocalStorageProvider().upload(file_data, file_key, content_type)
 

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple
 from uuid import UUID
 
 from fastapi import BackgroundTasks
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from app.models.order import Cart, CartItem, Order, OrderItem
@@ -333,28 +334,57 @@ def create_order(
         )
         db.add(order_item)
 
-        # Update stock
-        product = db.query(Product).filter(Product.id == item_data["product_id"]).first()
-        product.inventory_count -= item_data["quantity"]
+        # Decrement stock atomically. The guarded UPDATE (only decrements when
+        # enough stock remains) plus the rowcount check prevents two concurrent
+        # orders from both passing the earlier validation and overselling — a
+        # plain read-modify-write would lose one update under READ COMMITTED.
+        result = db.execute(
+            update(Product)
+            .where(
+                Product.id == item_data["product_id"],
+                Product.inventory_count >= item_data["quantity"],
+            )
+            .values(inventory_count=Product.inventory_count - item_data["quantity"])
+        )
+        if result.rowcount == 0:
+            db.rollback()
+            return False, f"Insufficient stock for '{item_data['product_title']}'", None
 
         if item_data["product_variant_id"]:
-            variant = (
-                db.query(ProductVariant)
-                .filter(ProductVariant.id == item_data["product_variant_id"])
-                .first()
+            variant_result = db.execute(
+                update(ProductVariant)
+                .where(
+                    ProductVariant.id == item_data["product_variant_id"],
+                    ProductVariant.inventory_count >= item_data["quantity"],
+                )
+                .values(
+                    inventory_count=ProductVariant.inventory_count - item_data["quantity"]
+                )
             )
-            variant.inventory_count -= item_data["quantity"]
+            if variant_result.rowcount == 0:
+                db.rollback()
+                return (
+                    False,
+                    f"Insufficient stock for '{item_data['product_title']}' variant",
+                    None,
+                )
 
-    # Increment promo code usage if used
+    # Increment promo code usage if used. This is the authoritative usage-limit
+    # gate: the atomic UPDATE only increments while the code is under its limit,
+    # so concurrent checkouts can't push it past usage_limit. No internal commit
+    # here — the whole order commits once below, so a crash can't leave the order
+    # persisted with the cart un-cleared (which would let the user re-order).
     if promo_code_id:
-        promo_code_service.increment_usage(db, promo_code_id)
+        if not promo_code_service.increment_usage_if_available(db, promo_code_id):
+            db.rollback()
+            return False, "This promo code has reached its usage limit", None
 
     # Clear cart
     if cart:
         for cart_item in cart.cart_items:
             db.delete(cart_item)
 
-    # Commit transaction
+    # Commit the entire order (order, items, stock, promo, cart clear) atomically
     db.commit()
     db.refresh(order)
 

--- a/backend/app/services/promo_code_service.py
+++ b/backend/app/services/promo_code_service.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import List, Optional, Tuple
 from uuid import UUID
 
-from sqlalchemy import or_
+from sqlalchemy import or_, update
 from sqlalchemy.orm import Session
 
 from app.models.order import PromoCode
@@ -281,6 +281,38 @@ def increment_usage(db: Session, promo_code_id: UUID) -> Optional[PromoCode]:
     db.refresh(promo_code)
 
     return promo_code
+
+
+def increment_usage_if_available(db: Session, promo_code_id: UUID) -> bool:
+    """
+    Atomically increment a promo code's usage count, but only while it is still
+    under its usage limit.
+
+    Unlike ``increment_usage``, this performs a single guarded UPDATE and does
+    NOT commit — the caller commits as part of the surrounding transaction. This
+    is race-safe: concurrent checkouts cannot both read the same usage_count and
+    each write limit+0, because the WHERE clause re-checks the limit atomically.
+
+    Args:
+        db: Database session
+        promo_code_id: Promo code ID
+
+    Returns:
+        True if the usage count was incremented (code was under its limit),
+        False if the limit is already reached or the code no longer exists.
+    """
+    result = db.execute(
+        update(PromoCode)
+        .where(
+            PromoCode.id == promo_code_id,
+            or_(
+                PromoCode.usage_limit.is_(None),
+                PromoCode.usage_count < PromoCode.usage_limit,
+            ),
+        )
+        .values(usage_count=PromoCode.usage_count + 1)
+    )
+    return result.rowcount > 0
 
 
 def is_expired(promo_code: PromoCode) -> bool:

--- a/backend/app/services/storage/factory.py
+++ b/backend/app/services/storage/factory.py
@@ -17,6 +17,16 @@ _cached_provider: Optional[StorageProvider] = None
 _cached_fingerprint: Optional[str] = None
 
 
+def _is_production() -> bool:
+    """True when running in production, where silently falling back to the
+    ephemeral local disk would lose uploads on the next redeploy."""
+    try:
+        from app.core.config import settings
+        return settings.ENVIRONMENT == "production"
+    except Exception:
+        return False
+
+
 def _read_storage_settings() -> dict:
     """Read storage-related keys from site_settings using a short-lived session."""
     from app.core.database import SessionLocal
@@ -66,6 +76,12 @@ def _build_provider(config: dict) -> StorageProvider:
                 region=config.get("storage_s3_region", "us-east-1"),
             )
         except Exception as e:
+            if _is_production():
+                logger.error(
+                    f"Failed to create S3 provider in production; refusing to fall "
+                    f"back to ephemeral local storage: {e}"
+                )
+                raise
             logger.warning(f"Failed to create S3 provider, falling back to local: {e}")
             return LocalStorageProvider()
 
@@ -86,6 +102,12 @@ def _build_provider(config: dict) -> StorageProvider:
                 api_secret=api_secret,
             )
         except Exception as e:
+            if _is_production():
+                logger.error(
+                    f"Failed to create Cloudinary provider in production; refusing to "
+                    f"fall back to ephemeral local storage: {e}"
+                )
+                raise
             logger.warning(f"Failed to create Cloudinary provider, falling back to local: {e}")
             return LocalStorageProvider()
 

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -33,6 +33,8 @@ services:
         value: us-east-1
       - key: S3_BUCKET_NAME
         sync: false
+      - key: EMAIL_PROVIDER
+        value: resend
       - key: RESEND_API_KEY
         sync: false
       - key: FROM_EMAIL

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -130,20 +130,30 @@ export default function CheckoutPage() {
         0
       );
 
-      const res = await fetch(
-        `${API_BASE_URL}${API_ENDPOINTS.PROMO_CODES.VALIDATE}?code=${encodeURIComponent(
-          promoCode
-        )}&orderAmount=${subtotal}`,
-        { headers: { Authorization: `Bearer ${session?.accessToken}` } }
-      );
+      // Public endpoint: POST a JSON body (the route is @router.post and takes
+      // { code, orderAmount }). No auth header — it's public, and a guest has
+      // no access token.
+      const res = await fetch(`${API_BASE_URL}${API_ENDPOINTS.PROMO_CODES.VALIDATE}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: promoCode.trim(), orderAmount: subtotal }),
+      });
 
       if (res.ok) {
         const data = await res.json();
-        setPromoDiscount(data.discountAmount || 0);
+        if (data.valid) {
+          setPromoDiscount(Number(data.discountAmount) || 0);
+          setError("");
+        } else {
+          // Valid HTTP 200 but the code was rejected — surface the reason.
+          setPromoDiscount(0);
+          setError(data.message || "Invalid promo code");
+          setTimeout(() => setError(""), 3000);
+        }
       } else {
         setPromoDiscount(0);
-        const errorData = await res.json();
-        setError(errorData.detail || "Invalid promo code");
+        const errorData = await res.json().catch(() => ({}));
+        setError(errorData.detail || "Could not validate promo code");
         setTimeout(() => setError(""), 3000);
       }
     } catch (err) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -155,7 +155,7 @@ export default function Home() {
     const loadWishlist = async () => {
       if (!authenticated || !session?.accessToken) return;
       try {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           headers: { Authorization: `Bearer ${session.accessToken}` },
         });
         if (res.ok) {
@@ -213,7 +213,7 @@ export default function Home() {
     setTogglingWishlistId(product.id);
     try {
       if (isInWishlist) {
-        const res = await fetch(`${API_BASE_URL}/wishlist/${product.id}`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist/${product.id}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${session?.accessToken}` },
         });
@@ -222,7 +222,7 @@ export default function Home() {
           toast.success("Removed from wishlist");
         }
       } else {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/frontend/src/app/products/[id]/page.tsx
+++ b/frontend/src/app/products/[id]/page.tsx
@@ -157,7 +157,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
     const checkWishlist = async () => {
       if (!authenticated || !product) return;
       try {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           headers: { Authorization: `Bearer ${session?.accessToken}` },
         });
         if (res.ok) {
@@ -231,7 +231,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
     setAddingToWishlist(true);
     try {
       if (inWishlist) {
-        const res = await fetch(`${API_BASE_URL}/wishlist/${product?.id}`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist/${product?.id}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${session?.accessToken}` },
         });
@@ -240,7 +240,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
           toast.success("Removed from wishlist");
         }
       } else {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -322,7 +322,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
     setRelatedTogglingWishlistId(rp.id);
     try {
       if (isIn) {
-        const res = await fetch(`${API_BASE_URL}/wishlist/${rp.id}`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist/${rp.id}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${session?.accessToken}` },
         });
@@ -331,7 +331,7 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
           toast.success("Removed from wishlist");
         }
       } else {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -171,7 +171,7 @@ function ProductsPageContent() {
     const loadWishlist = async () => {
       if (!authenticated || !session?.accessToken) return;
       try {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           headers: { Authorization: `Bearer ${session.accessToken}` },
         });
         if (res.ok) {
@@ -313,7 +313,7 @@ function ProductsPageContent() {
     setTogglingWishlistId(product.id);
     try {
       if (isInWishlist) {
-        const res = await fetch(`${API_BASE_URL}/wishlist/${product.id}`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist/${product.id}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${session?.accessToken}` },
         });
@@ -322,7 +322,7 @@ function ProductsPageContent() {
           toast.success("Removed from wishlist");
         }
       } else {
-        const res = await fetch(`${API_BASE_URL}/wishlist`, {
+        const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/frontend/src/app/wishlist/page.tsx
+++ b/frontend/src/app/wishlist/page.tsx
@@ -60,7 +60,7 @@ export default function WishlistPage() {
   const fetchWishlist = async () => {
     setLoading(true);
     try {
-      const res = await fetch(`${API_BASE_URL}/wishlist`, {
+      const res = await fetch(`${API_BASE_URL}/api/wishlist`, {
         headers: { Authorization: `Bearer ${session?.accessToken}` },
       });
 
@@ -80,7 +80,7 @@ export default function WishlistPage() {
 
     try {
       // Add to cart
-      const cartRes = await fetch(`${API_BASE_URL}/cart/items`, {
+      const cartRes = await fetch(`${API_BASE_URL}/api/cart/items`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -117,7 +117,7 @@ export default function WishlistPage() {
     }
 
     try {
-      const res = await fetch(`${API_BASE_URL}/wishlist/${productId}`, {
+      const res = await fetch(`${API_BASE_URL}/api/wishlist/${productId}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${session?.accessToken}` },
       });

--- a/frontend/src/components/providers/SessionProvider.tsx
+++ b/frontend/src/components/providers/SessionProvider.tsx
@@ -13,5 +13,13 @@ interface SessionProviderProps {
 }
 
 export function SessionProvider({ children }: SessionProviderProps) {
-  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>;
+  // Refetch the session every 5 minutes (and on window focus) so the backend
+  // access token — which lives 15 minutes and is refreshed inside the jwt
+  // callback — stays fresh even in a long-lived tab (e.g. a user filling in the
+  // checkout or booking form), instead of going stale and 401-ing on submit.
+  return (
+    <NextAuthSessionProvider refetchInterval={5 * 60} refetchOnWindowFocus>
+      {children}
+    </NextAuthSessionProvider>
+  );
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -25,9 +25,11 @@ export function useAuth() {
   const { data: session, status } = useSession();
   const loading = status === "loading";
 
-  // Check if we have a valid session with an access token
-  // If session exists but no accessToken, consider it expired/invalid
-  const hasValidToken = session?.accessToken != null;
+  // Check if we have a valid session with an access token.
+  // If the session has no accessToken, or a refresh failed (error flag set),
+  // consider it expired/invalid so the app forces re-authentication instead of
+  // carrying a stale token that 401s every request.
+  const hasValidToken = session?.accessToken != null && session?.error == null;
   const authenticated = status === "authenticated" && hasValidToken;
 
   const user = authenticated ? (session?.user as NextAuthUser | undefined) : undefined;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -106,10 +106,13 @@ export const authOptions: NextAuthOptions = {
         token.adminRole = session.adminRole;
       }
 
-      // Refresh access token and user data periodically
-      // Backend access token expires after 15 minutes, so refresh every 14 minutes
-      if (token.refreshToken && (!token.lastRefresh || Date.now() - (token.lastRefresh as number) > 14 * 60 * 1000)) {
+      // Refresh access token and user data periodically. The backend access
+      // token expires after 15 minutes; refresh at 10 to leave margin before a
+      // request would 401.
+      if (token.refreshToken && (!token.lastRefresh || Date.now() - (token.lastRefresh as number) > 10 * 60 * 1000)) {
         try {
+          // Clear any prior refresh error — we're attempting again.
+          delete token.error;
           // First, refresh the access token using the refresh token
           const refreshResponse = await axios.post(`${API_BASE_URL}${API_ENDPOINTS.AUTH.REFRESH}`, {
             refresh_token: token.refreshToken,
@@ -135,7 +138,10 @@ export const authOptions: NextAuthOptions = {
           }
         } catch (error) {
           console.error("Error refreshing token and user data:", error);
-          // If refresh fails, user will need to sign in again
+          // Flag the session so the client treats it as expired instead of
+          // silently carrying a stale/invalid token (which would 401 every
+          // write and empty the cart). useAuth reads this to force re-auth.
+          token.error = "RefreshTokenError";
         }
       }
 
@@ -162,6 +168,11 @@ export const authOptions: NextAuthOptions = {
       // Add tokens at session level
       session.accessToken = token.accessToken as string;
       session.refreshToken = token.refreshToken as string;
+
+      // Surface a failed token refresh so the client can force re-auth.
+      if (token.error) {
+        session.error = token.error as string;
+      }
 
       return session;
     },

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -35,6 +35,8 @@ declare module "next-auth" {
     };
     accessToken?: string;
     refreshToken?: string;
+    /** Set to "RefreshTokenError" when a backend token refresh failed. */
+    error?: string;
   }
 }
 
@@ -49,5 +51,7 @@ declare module "next-auth/jwt" {
     accessToken?: string;
     refreshToken?: string;
     lastRefresh?: number;
+    /** Set to "RefreshTokenError" when a backend token refresh failed. */
+    error?: string;
   }
 }


### PR DESCRIPTION
## Phase 2 of the production readiness roadmap — money-path correctness

### Backend correctness (concurrency-safe)
- **C6 — inventory oversell.** Stock now decrements via a guarded atomic `UPDATE ... WHERE inventory_count >= qty` with a rowcount check; concurrent orders can no longer both pass validation and oversell. Rolls back with a clear error if stock ran out.
- **H3 — promo usage limit race.** New `increment_usage_if_available` does an atomic `UPDATE ... WHERE usage_count < usage_limit`; the limit can't be exceeded by concurrent checkouts. No internal commit.
- **M1 — split commit.** `create_order` now commits once (order + items + stock + promo + cart clear), so a crash can't leave an order persisted with the cart intact (which caused double-ordering).
- **H4 — booking-number race.** Random 5-digit suffix instead of a count-then-format counter, with an `IntegrityError` retry on the unique constraint — no more 500s / lost bookings under concurrency.

### Delivery hardening (fails closed in production, unchanged in dev)
- **C4 — email.** Config read from `settings` (reconciles the `FROM_EMAIL`/`EMAIL_FROM` mismatch); startup fails in production if `EMAIL_PROVIDER` is `console` or its API key is missing, so orders/bookings can't silently not-send.
- **C5 — storage.** In production, provider-build and upload failures now raise instead of silently falling back to the ephemeral local disk (which loses uploads on the next redeploy while persisting a dead URL).

_Both guards are gated on `ENVIRONMENT=production`, so behavior is unchanged until the dashboard flips to production._

### Frontend
- **C7 — promo apply.** Now POSTs a JSON body and branches on `data.valid` (was a GET → 405 every time), surfacing the reason for invalid codes.
- **M4 — wishlist 404s.** Wishlist/cart fetch URLs now include the `/api` prefix.
- **H6/M5 — session resilience.** A failed token refresh flags the session so `useAuth` forces re-auth (no more zombie session / silently-emptied cart); token refreshes at 10 min and the session refetches every 5 min, so long checkout/booking sessions don't submit with a stale token.

### Verification
- All changed backend files compile; `app.main` imports clean; the new atomic paths preserve existing test behavior (booking-number test fixtures are hardcoded, not generator assertions).
- Frontend `tsc --noEmit` passes clean.
- Full pytest suite requires Postgres (unavailable in this env) — runs under CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)